### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 This is a simple [Model Context Protocol](https://modelcontextprotocol.io) server that uses the [ipinfo.io](https://ipinfo.io) API to get detailed information about an IP address.
 This can be used to determine where the user is located (approximately) and what network they are used.
 
+<a href="https://glama.ai/mcp/servers/pll7u5ak1h">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/pll7u5ak1h/badge" alt="IP Geolocation Server MCP server" />
+</a>
+
 ![Example conversation using mcp-server-ipinfo](demo.png)
 
 


### PR DESCRIPTION
This PR adds a badge for the [IP Geolocation MCP Server](https://glama.ai/mcp/servers/pll7u5ak1h) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/pll7u5ak1h">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/pll7u5ak1h/badge" alt="IP Geolocation Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.