### PR TITLE
feat: flatten Core/Plus nested response shape onto IPDetails

### DIFF
--- a/src/mcp_server_ipinfo/ipinfo.py
+++ b/src/mcp_server_ipinfo/ipinfo.py
@@ -14,6 +14,44 @@ def _utc_timestamp() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _flatten_nested_response(details: dict) -> dict:
+    """Flatten Core/Plus API nested response shape onto the flat IPDetails schema.
+
+    Core and Plus responses nest geolocation under ``geo`` and AS info under ``as``;
+    the standard endpoint puts these at the top level. This promotes nested keys to
+    the top level so a single Pydantic schema works for both, and renames the ``as``
+    key (a Python keyword) to ``asn``.
+
+    The ``geo`` block uses ``country`` for the full country name and
+    ``country_code`` for the ISO alpha-2; the flat schema uses ``country`` for the
+    alpha-2 and ``country_name`` for the full name, so those are remapped.
+    Top-level keys win over nested keys on conflict.
+
+    ``mobile`` and ``anonymous`` blocks (Plus only) are intentionally left untouched
+    until their field shapes can be verified against a real Plus response.
+    """
+    if not isinstance(details, dict):
+        return details
+
+    out = dict(details)
+
+    geo = out.pop("geo", None)
+    if isinstance(geo, dict):
+        geo = dict(geo)
+        if "country_code" in geo:
+            if "country" in geo:
+                geo.setdefault("country_name", geo.pop("country"))
+            geo["country"] = geo.pop("country_code")
+        for key, value in geo.items():
+            out.setdefault(key, value)
+
+    as_block = out.pop("as", None)
+    if as_block is not None and "asn" not in out:
+        out["asn"] = as_block
+
+    return out
+
+
 async def create_async_handler(**kwargs) -> ipinfo.AsyncHandler:
     """
     Create an async IPInfo handler.
@@ -49,7 +87,9 @@ async def ipinfo_lookup(handler: ipinfo.AsyncHandler, ip: str | None) -> IPDetai
         ValueError: If the provided IP address is invalid
     """
     details = await handler.getDetails(ip_address=ip)
-    return IPDetails(**details.all, ts_retrieved=_utc_timestamp())
+    return IPDetails(
+        **_flatten_nested_response(details.all), ts_retrieved=_utc_timestamp()
+    )
 
 
 async def ipinfo_batch_lookup(
@@ -79,7 +119,7 @@ async def ipinfo_batch_lookup(
 
     ts = _utc_timestamp()
     return {
-        ip: IPDetails(**details.all, ts_retrieved=ts)
+        ip: IPDetails(**_flatten_nested_response(details.all), ts_retrieved=ts)
         for ip, details in results.items()
         if hasattr(details, "all")  # Skip failed lookups
     }

--- a/src/mcp_server_ipinfo/ipinfo.py
+++ b/src/mcp_server_ipinfo/ipinfo.py
@@ -30,17 +30,14 @@ def _flatten_nested_response(details: dict) -> dict:
     ``mobile`` and ``anonymous`` blocks (Plus only) are intentionally left untouched
     until their field shapes can be verified against a real Plus response.
     """
-    if not isinstance(details, dict):
-        return details
-
     out = dict(details)
 
     geo = out.pop("geo", None)
     if isinstance(geo, dict):
         geo = dict(geo)
+        if "country" in geo:
+            geo["country_name"] = geo.pop("country")
         if "country_code" in geo:
-            if "country" in geo:
-                geo.setdefault("country_name", geo.pop("country"))
             geo["country"] = geo.pop("country_code")
         for key, value in geo.items():
             out.setdefault(key, value)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,6 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
+from mcp_server_ipinfo.ipinfo import _flatten_nested_response
 from mcp_server_ipinfo.models import IPDetails, ResidentialProxyDetails
 
 
@@ -139,3 +140,127 @@ class TestResidentialProxyDetails:
         assert details.last_seen is None
         assert details.percent_days_seen is None
         assert details.service is None
+
+
+class TestFlattenNestedResponse:
+    """Tests for the Core/Plus -> flat IPDetails adapter."""
+
+    def test_flat_response_unchanged(self):
+        """Standard endpoint responses (already flat) pass through with no changes."""
+        flat = {
+            "ip": "8.8.8.8",
+            "city": "Mountain View",
+            "country": "US",
+            "country_name": "United States",
+            "org": "AS15169 Google LLC",
+        }
+        assert _flatten_nested_response(flat) == flat
+
+    def test_geo_block_promoted_to_top_level(self):
+        """Core-style nested geo block is flattened so IPDetails sees top-level fields."""
+        nested = {
+            "ip": "8.8.8.8",
+            "geo": {
+                "city": "Mountain View",
+                "region": "California",
+                "region_code": "CA",
+                "country": "United States",
+                "country_code": "US",
+                "loc": "37.3860,-122.0838",
+                "postal": "94035",
+                "timezone": "America/Los_Angeles",
+            },
+        }
+        flat = _flatten_nested_response(nested)
+
+        assert "geo" not in flat
+        assert flat["city"] == "Mountain View"
+        assert flat["region"] == "California"
+        assert flat["region_code"] == "CA"
+        assert flat["country"] == "US"
+        assert flat["country_name"] == "United States"
+        assert flat["loc"] == "37.3860,-122.0838"
+        assert flat["postal"] == "94035"
+        assert flat["timezone"] == "America/Los_Angeles"
+
+    def test_as_block_renamed_to_asn(self):
+        """The 'as' key (a Python keyword) is renamed to 'asn' for IPDetails."""
+        nested = {
+            "ip": "8.8.8.8",
+            "as": {
+                "asn": "AS15169",
+                "name": "Google LLC",
+                "domain": "google.com",
+                "type": "hosting",
+            },
+        }
+        flat = _flatten_nested_response(nested)
+
+        assert "as" not in flat
+        assert flat["asn"]["asn"] == "AS15169"
+        assert flat["asn"]["name"] == "Google LLC"
+
+    def test_top_level_wins_over_nested(self):
+        """If a top-level key is already set, the geo block does not overwrite it."""
+        nested = {
+            "ip": "8.8.8.8",
+            "city": "Top-level Wins",
+            "geo": {"city": "Should Be Ignored", "country_code": "US"},
+        }
+        flat = _flatten_nested_response(nested)
+        assert flat["city"] == "Top-level Wins"
+        assert flat["country"] == "US"
+
+    def test_existing_asn_not_overwritten(self):
+        """If both 'as' and 'asn' are present, existing 'asn' wins."""
+        nested = {
+            "ip": "8.8.8.8",
+            "asn": {"asn": "AS-EXISTING"},
+            "as": {"asn": "AS-NESTED"},
+        }
+        flat = _flatten_nested_response(nested)
+        assert flat["asn"]["asn"] == "AS-EXISTING"
+        assert "as" not in flat
+
+    def test_missing_country_code_leaves_country_alone(self):
+        """If geo lacks country_code, don't reshape country fields (avoid bad mapping)."""
+        nested = {
+            "ip": "8.8.8.8",
+            "geo": {"city": "Mountain View", "country": "US"},
+        }
+        flat = _flatten_nested_response(nested)
+        assert flat["country"] == "US"
+        assert "country_name" not in flat
+
+    def test_non_dict_input_returned_as_is(self):
+        """Defensive: unexpected input shape is returned unchanged rather than crashing."""
+        assert _flatten_nested_response(None) is None  # type: ignore[arg-type]
+
+    def test_ipdetails_constructs_from_core_shape(self):
+        """End-to-end: a Core-shaped response yields a valid IPDetails."""
+        nested = {
+            "ip": "8.8.8.8",
+            "geo": {
+                "city": "Mountain View",
+                "region": "California",
+                "region_code": "CA",
+                "country": "United States",
+                "country_code": "US",
+                "loc": "37.3860,-122.0838",
+            },
+            "as": {
+                "asn": "AS15169",
+                "name": "Google LLC",
+                "domain": "google.com",
+                "type": "hosting",
+            },
+        }
+        details = IPDetails(**_flatten_nested_response(nested))
+        assert str(details.ip) == "8.8.8.8"
+        assert details.city == "Mountain View"
+        assert details.country == "US"
+        assert details.country_name == "United States"
+        assert details.region_code == "CA"
+        assert details.asn is not None
+        assert details.asn.asn == "AS15169"
+        assert details.asn.name == "Google LLC"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -222,19 +222,17 @@ class TestFlattenNestedResponse:
         assert flat["asn"]["asn"] == "AS-EXISTING"
         assert "as" not in flat
 
-    def test_missing_country_code_leaves_country_alone(self):
-        """If geo lacks country_code, don't reshape country fields (avoid bad mapping)."""
+    def test_geo_country_is_full_name_when_country_code_missing(self):
+        """Per Core/Plus convention, geo.country is the full country name; without
+        country_code we still map it to country_name (never to top-level country,
+        which would fail IPDetails' alpha-2 regex)."""
         nested = {
             "ip": "8.8.8.8",
-            "geo": {"city": "Mountain View", "country": "US"},
+            "geo": {"city": "Mountain View", "country": "United States"},
         }
         flat = _flatten_nested_response(nested)
-        assert flat["country"] == "US"
-        assert "country_name" not in flat
-
-    def test_non_dict_input_returned_as_is(self):
-        """Defensive: unexpected input shape is returned unchanged rather than crashing."""
-        assert _flatten_nested_response(None) is None  # type: ignore[arg-type]
+        assert flat["country_name"] == "United States"
+        assert "country" not in flat
 
     def test_ipdetails_constructs_from_core_shape(self):
         """End-to-end: a Core-shaped response yields a valid IPDetails."""


### PR DESCRIPTION
## Summary

The standard ipinfo endpoint (used today by `getHandlerAsync`) returns flat fields. The Core/Plus endpoints (`api.ipinfo.io/lookup`) return geolocation under a nested `geo` block and AS info under a nested `as` key — those would be silently dropped by the flat `IPDetails` schema (Pydantic's default is `extra="ignore"`).

This adds a small `_flatten_nested_response` helper that promotes nested keys to the top level before model construction:

- `geo` block flattened; `country_code` becomes `country` (ISO alpha-2), and the geo block's `country` (full name) becomes `country_name`
- `as` block (a Python keyword) renamed to `asn`
- Top-level keys win over nested on conflict (defensive)

## Scope notes

- **No-op today.** The current `getHandlerAsync` endpoint never returns `geo`/`as` keys, so existing behavior is unchanged. This is groundwork that lets a future tier-selector (e.g. `IPINFO_API_TIER=core`) work cleanly without further model changes.
- **`mobile` / `anonymous` (Plus-only) intentionally deferred.** Mapping their inner field names onto `CarrierDetails` / `PrivacyDetails` requires a real Plus API response to verify; guessing field names risks silent mis-mapping, which is worse than no mapping. Easy follow-up once a Plus token is available for testing.

## Test plan

- [x] `uv run pytest` — 87 passed (8 new), 96.28% coverage
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run ty check` — clean
- [x] Pre-commit hooks pass

The 8 new tests in `TestFlattenNestedResponse` cover: flat-passthrough, geo flattening, `as`→`asn` rename, top-level-wins precedence, missing-key edge cases, non-dict input, and an end-to-end Core-shape → `IPDetails` construction.