### PR TITLE
Structured error envelopes, split lookup tools, ipinfo_ prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `ipinfo_lookup_my_ip` tool for looking up the calling client's own IP (no arguments)
+- `ipinfo_lookup_ips` tool for looking up one or more specified IPs, with a `detail: "summary" | "full"` toggle that nulls heavy nested blocks (`continent`, `country_flag*`, `country_currency`, `abuse`, `domains`) for batch token savings while preserving shape parity
+- `ipinfo_check_residential_proxy` and `ipinfo_generate_map_url` (renamed from the originals)
+- `ToolErrorEnvelope` Pydantic model with stable symbolic codes (`invalid_ip_address`, `special_ip_unsupported`, `no_valid_ips`, `too_many_ips`, `auth_invalid`, `auth_insufficient_scope`, `quota_exceeded`, `timeout`, `api_error`, `unknown_error`); JSON-encoded into every `ToolError` so agents can branch on `code` without parsing prose
+- Per-tool metadata: `meta={"introduced_in": "0.5.0"}` on all new tools; `tags={"enterprise"}` and `meta={"plan_required": "residential_proxy_addon"}` on `ipinfo_check_residential_proxy`
+- Schema-level `maxItems: 500_000` constraint on `ips` arrays so MCP clients can reject oversized inputs without a round-trip
+
+### Changed
+- Tool errors now distinguish missing/invalid token (`auth_invalid`) from insufficient plan scope (`auth_insufficient_scope`) instead of collapsing to one opaque message
+- Quota and timeout failures map to `quota_exceeded` / `timeout` codes with `temporary: true` so agents know to retry
+- Server `instructions` document the structured error contract and list both current and deprecated tool names
+
+### Deprecated
+- `get_ip_details`, `get_residential_proxy_info`, `get_map_url` retained as forwarding aliases tagged `deprecated` with `meta.replaced_by`; **scheduled for removal in 0.6.0**
+
 ## [0.4.0] - 2026-04-11
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-ipinfo"
-version = "0.4.0"
+version = "0.5.0"
 description = "IP Geolocation Server for MCP"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/mcp_server_ipinfo/models.py
+++ b/src/mcp_server_ipinfo/models.py
@@ -1,8 +1,56 @@
 from decimal import Decimal
-from typing import Annotated
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field, StringConstraints
 from pydantic.networks import HttpUrl, IPvAnyAddress
+
+
+ToolErrorCode = Literal[
+    "invalid_ip_address",
+    "special_ip_unsupported",
+    "no_valid_ips",
+    "too_many_ips",
+    "auth_invalid",
+    "auth_insufficient_scope",
+    "quota_exceeded",
+    "timeout",
+    "api_error",
+    "unknown_error",
+]
+
+
+class ToolErrorEnvelope(BaseModel):
+    """Structured error envelope serialized into a ToolError message string.
+
+    The envelope gives agents stable symbolic codes, a repair hint, and
+    retry guidance instead of an opaque prose-only error. JSON-encoded into
+    a ``ToolError`` so that the wire-level ``isError: true`` still applies
+    while the message body remains parseable.
+    """
+
+    code: ToolErrorCode
+    """Stable symbolic identifier for branching on the error."""
+
+    message: str
+    """Human-readable summary; safe to surface to end users."""
+
+    temporary: bool
+    """True if the agent should retry after a delay; False if the call will keep failing."""
+
+    field: str | None = None
+    """Name of the offending input field, when applicable."""
+
+    value: Any = None
+    """Offending value (redact in repair hint if sensitive)."""
+
+    retry_after_ms: int | None = None
+    """Milliseconds the agent should wait before retrying, when temporary=True."""
+
+    repair: dict[str, Any] | None = None
+    """Free-form repair guidance: hint text, alternative tool, allowed values."""
+
+    request_id: str | None = None
+    """Correlation identifier for the originating request, if available."""
 
 
 class ASNDetails(BaseModel):

--- a/src/mcp_server_ipinfo/server.py
+++ b/src/mcp_server_ipinfo/server.py
@@ -62,10 +62,10 @@ mcp = FastMCP(
     An IPv6 address consists of eight groups of four hexadecimal numbers separated by colons (:).
 
     All tool errors carry a JSON-encoded ToolErrorEnvelope in the error message
-    with a stable `code` (e.g., auth_invalid, auth_insufficient_scope,
+    with a stable `code` (one of: auth_invalid, auth_insufficient_scope,
     quota_exceeded, timeout, api_error, invalid_ip_address, special_ip_unsupported,
-    no_valid_ips, too_many_ips), a `temporary` flag, an optional `retry_after_ms`,
-    and a `repair` hint. Parse the error string as JSON to branch.
+    no_valid_ips, too_many_ips, unknown_error), a `temporary` flag, an optional
+    `retry_after_ms`, and a `repair` hint. Parse the error string as JSON to branch.
     """,
     lifespan=app_lifespan,
 )
@@ -203,12 +203,17 @@ def _envelope_from_upstream(
             None,
             {"hint": "Retry; transient network or upstream slowness."},
         )
+    # Catch-all: surface the exception class name as a structured field so
+    # agents can branch on type without parsing the message. The raw
+    # `str(exc)` is included to preserve diagnostic context (we run with
+    # mask_error_details=False); upstream library messages should not embed
+    # secrets, but callers wanting redaction can flip mask_error_details.
     return (
         "unknown_error",
-        f"Unexpected error: {exc}",
+        f"Unexpected {type(exc).__name__}: {exc}",
         True,
         None,
-        None,
+        {"exception_type": type(exc).__name__},
     )
 
 
@@ -342,6 +347,23 @@ async def _do_batch_lookup(
 
     Shared between ipinfo_lookup_ips and the deprecated get_ip_details alias.
     """
+    # Defense-in-depth: schema enforces the cap, but direct Python invocation
+    # (or any caller bypassing FastMCP validation) can still pass an arbitrary
+    # list. Reject early before any per-IP work.
+    if len(ips) > MAX_LOOKUP_IPS:
+        _raise_envelope(
+            "too_many_ips",
+            f"Too many IPs ({len(ips)}). Maximum is {MAX_LOOKUP_IPS:,} per lookup.",
+            temporary=False,
+            field="ips",
+            value=len(ips),
+            repair={
+                "limit": MAX_LOOKUP_IPS,
+                "received": len(ips),
+                "hint": f"Reduce ips to <= {MAX_LOOKUP_IPS} entries.",
+            },
+        )
+
     valid_ips, skipped = await _filter_valid_ips(ips, ctx)
 
     if not valid_ips:

--- a/src/mcp_server_ipinfo/server.py
+++ b/src/mcp_server_ipinfo/server.py
@@ -1,12 +1,15 @@
 import ipaddress
+import json
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Annotated
+from typing import Annotated, Any, Literal, NoReturn
 
 import ipinfo
 from fastmcp import Context, FastMCP
 from fastmcp.dependencies import CurrentContext
 from fastmcp.exceptions import ToolError
+from ipinfo.error import APIError
+from ipinfo.exceptions import RequestQuotaExceededError, TimeoutExceededError
 from pydantic import Field
 
 from .cache import IPInfoCache
@@ -17,7 +20,7 @@ from .ipinfo import (
     ipinfo_lookup,
     ipinfo_resproxy_lookup,
 )
-from .models import IPDetails, ResidentialProxyDetails
+from .models import IPDetails, ResidentialProxyDetails, ToolErrorCode, ToolErrorEnvelope
 
 
 @asynccontextmanager
@@ -40,10 +43,13 @@ mcp = FastMCP(
     For a given IPv4 or IPv6 address, it provides information about the geographic location
     of that device, the internet service provider, and additional information about the connection.
 
-    Available tools:
-    - get_ip_details: Look up details for one or more IP addresses
-    - get_residential_proxy_info: Check if an IP is a residential proxy
-    - get_map_url: Generate an interactive map URL showing IP locations
+    Available tools (current, ipinfo_-prefixed):
+    - ipinfo_lookup_my_ip: Look up details for the calling client's own IP address
+    - ipinfo_lookup_ips: Look up details for one or more specific IPs (supports detail="summary" for batch token savings)
+    - ipinfo_check_residential_proxy: Check if an IP belongs to a residential proxy network
+    - ipinfo_generate_map_url: Generate an interactive map URL for a set of IP locations
+
+    Deprecated aliases (will be removed in 0.6.0): get_ip_details, get_residential_proxy_info, get_map_url.
 
     The IPInfo API is free to use with rate limits. Paid plans provide more information.
     Set the IPINFO_API_TOKEN environment variable with a valid API key for premium features.
@@ -54,6 +60,12 @@ mcp = FastMCP(
 
     An IPv4 address consists of four decimal numbers separated by dots (.).
     An IPv6 address consists of eight groups of four hexadecimal numbers separated by colons (:).
+
+    All tool errors carry a JSON-encoded ToolErrorEnvelope in the error message
+    with a stable `code` (e.g., auth_invalid, auth_insufficient_scope,
+    quota_exceeded, timeout, api_error, invalid_ip_address, special_ip_unsupported,
+    no_valid_ips, too_many_ips), a `temporary` flag, an optional `retry_after_ms`,
+    and a `repair` hint. Parse the error string as JSON to branch.
     """,
     lifespan=app_lifespan,
 )
@@ -77,30 +89,173 @@ _IP_CHECKS = [
 
 _NORMALIZE_SENTINELS = frozenset({"null", "", "undefined", "0.0.0.0", "::"})
 
+# Heavy nested blocks dropped from IPDetails when an agent requests detail="summary".
+# These fields contribute the most tokens per record without being load-bearing for
+# typical batch tasks (geolocation, ASN). Core fields (ip, city, country, org, loc,
+# timezone, asn, privacy) survive summarization.
+_HEAVY_NESTED_FIELDS: tuple[str, ...] = (
+    "continent",
+    "country_flag",
+    "country_flag_url",
+    "country_currency",
+    "abuse",
+    "domains",
+)
+
+DetailLevel = Literal["summary", "full"]
+
+MAX_LOOKUP_IPS = 500_000
+
+
+def _raise_envelope(
+    code: ToolErrorCode,
+    message: str,
+    *,
+    temporary: bool,
+    field: str | None = None,
+    value: Any = None,
+    retry_after_ms: int | None = None,
+    repair: dict[str, Any] | None = None,
+) -> NoReturn:
+    """Build a ToolErrorEnvelope and raise it as a JSON-encoded ToolError.
+
+    Encoding the envelope into the ToolError message preserves the wire-level
+    `isError: true` while giving agents a parseable structured payload.
+    """
+    envelope = ToolErrorEnvelope(
+        code=code,
+        message=message,
+        temporary=temporary,
+        field=field,
+        value=value,
+        retry_after_ms=retry_after_ms,
+        repair=repair,
+    )
+    raise ToolError(envelope.model_dump_json())
+
+
+def _envelope_from_upstream(
+    exc: Exception,
+) -> tuple[ToolErrorCode, str, bool, int | None, dict[str, Any] | None]:
+    """Classify an upstream exception into the structured-error fields.
+
+    Returns ``(code, message, temporary, retry_after_ms, repair)``. The mapping
+    distinguishes auth failures from quota and timeout failures so agents can
+    take different repair paths.
+    """
+    if isinstance(exc, APIError):
+        if exc.error_code == 401:
+            return (
+                "auth_invalid",
+                "IPInfo rejected the provided API token.",
+                False,
+                None,
+                {
+                    "hint": (
+                        "Set IPINFO_API_TOKEN to a valid IPInfo API token. "
+                        "Sign up at https://ipinfo.io/signup."
+                    ),
+                },
+            )
+        if exc.error_code == 403:
+            return (
+                "auth_insufficient_scope",
+                "IPInfo plan does not grant access to this capability.",
+                False,
+                None,
+                {
+                    "hint": (
+                        "Upgrade your IPInfo plan or enable the required add-on "
+                        "(e.g., residential proxy data)."
+                    ),
+                },
+            )
+        if 500 <= exc.error_code < 600:
+            return (
+                "api_error",
+                f"IPInfo returned HTTP {exc.error_code}.",
+                True,
+                None,
+                {
+                    "hint": "Retry after a short delay; the upstream service is degraded."
+                },
+            )
+        return (
+            "api_error",
+            f"IPInfo returned HTTP {exc.error_code}.",
+            False,
+            None,
+            None,
+        )
+    if isinstance(exc, RequestQuotaExceededError):
+        return (
+            "quota_exceeded",
+            "IPInfo request quota exceeded for this token.",
+            True,
+            None,
+            {"hint": "Wait for daily quota reset or upgrade your IPInfo plan."},
+        )
+    if isinstance(exc, TimeoutExceededError):
+        return (
+            "timeout",
+            "IPInfo request timed out.",
+            True,
+            None,
+            {"hint": "Retry; transient network or upstream slowness."},
+        )
+    return (
+        "unknown_error",
+        f"Unexpected error: {exc}",
+        True,
+        None,
+        None,
+    )
+
+
+def _raise_from_upstream(exc: Exception) -> NoReturn:
+    """Translate an upstream exception into a structured ToolError envelope."""
+    code, message, temporary, retry_after_ms, repair = _envelope_from_upstream(exc)
+    _raise_envelope(
+        code,
+        message,
+        temporary=temporary,
+        retry_after_ms=retry_after_ms,
+        repair=repair,
+    )
+
 
 def _validate_ip(ip: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
-    """
-    Validate an IP address and check for special addresses.
+    """Validate an IP address and reject special-use addresses.
 
-    Args:
-        ip: The IP address string to validate.
-
-    Returns:
-        The parsed IP address object.
-
-    Raises:
-        ToolError: If the IP is invalid or is a special address type.
+    Raises a structured ToolError envelope (``invalid_ip_address`` or
+    ``special_ip_unsupported``) so callers receive an agent-actionable error
+    instead of opaque prose.
     """
     try:
         parsed_ip = ipaddress.ip_address(ip)
     except ValueError:
-        raise ToolError(f"{ip} is not a valid IP address")
+        _raise_envelope(
+            "invalid_ip_address",
+            f"{ip} is not a valid IP address.",
+            temporary=False,
+            field="ip",
+            value=ip,
+            repair={"hint": "Provide a valid IPv4 (e.g., 8.8.8.8) or IPv6 address."},
+        )
 
     # Check in order of specificity - loopback and reserved are subsets of private
     for attr, label in _IP_CHECKS:
         if getattr(parsed_ip, attr):
-            raise ToolError(
-                f"{ip} is a {label} IP address. Geolocation is not available."
+            _raise_envelope(
+                "special_ip_unsupported",
+                f"{ip} is a {label} IP address. Geolocation is not available.",
+                temporary=False,
+                field="ip",
+                value=ip,
+                repair={
+                    "hint": f"{label.capitalize()} addresses are not publicly geolocatable.",
+                    "class": label,
+                },
             )
 
     return parsed_ip
@@ -112,6 +267,14 @@ def _normalize_ip(ip: str) -> str | None:
     if ip in _NORMALIZE_SENTINELS:
         return None
     return ip
+
+
+def _envelope_message(err: ToolError) -> str:
+    """Extract the readable message from a structured ToolError, or fall back to str(err)."""
+    try:
+        return json.loads(str(err))["message"]
+    except (json.JSONDecodeError, KeyError, TypeError):
+        return str(err)
 
 
 async def _filter_valid_ips(
@@ -136,7 +299,7 @@ async def _filter_valid_ips(
             _validate_ip(norm)
             valid.append(norm)
         except ToolError as e:
-            skipped.append((ip, str(e)))
+            skipped.append((ip, _envelope_message(e)))
 
     for ip, reason in skipped:
         await ctx.warning(f"Skipping {ip}: {reason}")
@@ -144,72 +307,62 @@ async def _filter_valid_ips(
     return valid, skipped
 
 
-@mcp.tool(
-    annotations={
-        "readOnlyHint": True,
-        "openWorldHint": True,
-    }
-)
-async def get_ip_details(
-    ips: Annotated[
-        list[str] | None,
-        Field(
-            description="IP address(es) to analyze (IPv4 or IPv6). Pass a list of one or more IPs. If not provided, analyzes the requesting client's IP address.",
-            examples=[["8.8.8.8"], ["8.8.8.8", "1.1.1.1", "208.67.222.222"]],
-        ),
-    ] = None,
-    ctx: Context = CurrentContext(),
-) -> list[IPDetails]:
-    """Get detailed information about IP addresses including location, ISP, and network details.
+def _summarize_for_batch(details: IPDetails) -> IPDetails:
+    """Drop heavy nested blocks from an IPDetails for batch token efficiency.
 
-    This tool provides comprehensive IP address analysis including geographic location,
-    internet service provider information, and network details.
-
-    Common use cases:
-    - Analyze user's current location and connection details (omit ips parameter)
-    - Investigate one or more IP addresses for security analysis
-    - Look up ISP and hosting provider information
-    - Analyze server logs to identify visitor locations
-    - Geographic distribution analysis
-
-    Returns a list of IPDetails, each with: ip, hostname, city, region, country, postal,
-    timezone, org, loc (coordinates), and premium fields like asn, privacy, carrier if available.
-
-    Invalid or special IPs (private, loopback, etc.) are skipped with warnings.
-    Use the 'ip' field in results to match back to your input.
-
-    Note: Some features require IPINFO_API_TOKEN environment variable.
+    Returns a copy with the deeply-nested decorative fields nulled out
+    (continent, country_flag, country_flag_url, country_currency, abuse,
+    domains). Shape parity with full detail is preserved so existing
+    parsers continue to work.
     """
-    handler, cache = _get_handler_and_cache(ctx)
+    return details.model_copy(update={field: None for field in _HEAVY_NESTED_FIELDS})
 
-    # Handle client IP lookup (no IPs provided)
-    if ips is None:
-        await ctx.info("Looking up client IP details")
-        try:
-            result = await ipinfo_lookup(handler, None)
-            await cache.set(str(result.ip), result)
-            return [result]
-        except Exception as e:
-            await ctx.error(f"Failed to look up client IP: {e}")
-            raise ToolError(f"Lookup failed: {e}")
 
+async def _do_my_ip_lookup(
+    handler: ipinfo.AsyncHandler, cache: IPInfoCache, ctx: Context
+) -> IPDetails:
+    """Look up details for the client's own IP. Shared by ipinfo_lookup_my_ip and the deprecated alias."""
+    await ctx.info("Looking up client IP details")
+    try:
+        result = await ipinfo_lookup(handler, None)
+        await cache.set(str(result.ip), result)
+        return result
+    except Exception as e:
+        await ctx.error(f"Failed to look up client IP: {e}")
+        _raise_from_upstream(e)
+
+
+async def _do_batch_lookup(
+    handler: ipinfo.AsyncHandler,
+    cache: IPInfoCache,
+    ips: list[str],
+    ctx: Context,
+) -> list[IPDetails]:
+    """Validate, dedupe, cache-check, and look up a batch of IPs.
+
+    Shared between ipinfo_lookup_ips and the deprecated get_ip_details alias.
+    """
     valid_ips, skipped = await _filter_valid_ips(ips, ctx)
 
     if not valid_ips:
-        raise ToolError("No valid IP addresses provided")
+        _raise_envelope(
+            "no_valid_ips",
+            "No valid IP addresses provided; all inputs were filtered as invalid or special-use.",
+            temporary=False,
+            field="ips",
+            repair={
+                "hint": "Provide at least one public IPv4 or IPv6 address.",
+                "skipped_count": len(skipped),
+            },
+        )
 
-    # Check cache
     cached_results = await cache.get_batch(valid_ips)
     ips_to_lookup = [ip for ip in valid_ips if ip not in cached_results]
 
     if cached_results:
         await ctx.info(f"Found {len(cached_results)} IPs in cache")
 
-    if not ips_to_lookup and not cached_results:
-        raise ToolError("No valid IP addresses to look up")
-
-    # Perform lookup for non-cached IPs
-    new_results = {}
+    new_results: dict[str, IPDetails] = {}
     if ips_to_lookup:
         await ctx.info(f"Looking up {len(ips_to_lookup)} IP address(es)")
         try:
@@ -223,9 +376,8 @@ async def get_ip_details(
             await cache.set_batch(new_results)
         except Exception as e:
             await ctx.error(f"IP lookup failed: {e}")
-            raise ToolError(f"Lookup failed: {e}")
+            _raise_from_upstream(e)
 
-    # Combine and return in original order
     all_results = {**cached_results, **new_results}
     ordered_results = [all_results[ip] for ip in valid_ips if ip in all_results]
 
@@ -238,12 +390,95 @@ async def get_ip_details(
 
 
 @mcp.tool(
-    annotations={
-        "readOnlyHint": True,
-        "openWorldHint": True,
-    }
+    annotations={"readOnlyHint": True, "openWorldHint": True},
+    meta={"introduced_in": "0.5.0"},
 )
-async def get_residential_proxy_info(
+async def ipinfo_lookup_my_ip(
+    ctx: Context = CurrentContext(),
+) -> IPDetails:
+    """Return geolocation and ISP details for the calling client's own IP address.
+
+    Useful when an agent wants to ground "where am I" without taking the IP as
+    an argument. The result depends on the transport: on HTTP transports the
+    IPInfo API observes the requesting party's IP; on stdio the result reflects
+    the IP that the IPInfo API sees from this MCP server's outbound connection.
+    For looking up specific IPs, use `ipinfo_lookup_ips` instead.
+
+    Errors are JSON-encoded ToolErrorEnvelopes.
+    """
+    handler, cache = _get_handler_and_cache(ctx)
+    return await _do_my_ip_lookup(handler, cache, ctx)
+
+
+@mcp.tool(
+    annotations={"readOnlyHint": True, "openWorldHint": True},
+    meta={"introduced_in": "0.5.0"},
+)
+async def ipinfo_lookup_ips(
+    ips: Annotated[
+        list[str],
+        Field(
+            description=(
+                "List of IPv4 or IPv6 addresses to look up. Must contain at least 1 entry; "
+                "max 500,000. Invalid or special-use IPs (private, loopback, etc.) are filtered "
+                "with warnings."
+            ),
+            min_length=1,
+            max_length=MAX_LOOKUP_IPS,
+            examples=[["8.8.8.8"], ["8.8.8.8", "1.1.1.1", "208.67.222.222"]],
+        ),
+    ],
+    detail: Annotated[
+        DetailLevel,
+        Field(
+            description=(
+                "Response density. 'full' (default) returns every IPDetails field. "
+                "'summary' nulls heavy nested blocks (continent, country_flag*, "
+                "country_currency, abuse, domains) for batch token savings while "
+                "preserving shape parity."
+            ),
+        ),
+    ] = "full",
+    ctx: Context = CurrentContext(),
+) -> list[IPDetails]:
+    """Look up geolocation, ISP, and network details for one or more IP addresses.
+
+    Returns a list of IPDetails preserving input order (after dedup and
+    invalid-IP filtering). Use the `ip` field on each result to match back to
+    your input.
+
+    Common use cases:
+    - Investigate one or more IP addresses for security analysis
+    - Look up ISP and hosting provider information for a known address
+    - Analyze server logs to identify visitor locations
+    - Geographic distribution analysis across many IPs
+
+    Detail toggle:
+    - `detail="full"` (default): every available field, including decorative
+      blocks like continent metadata and country flags.
+    - `detail="summary"`: same shape, but heavy nested blocks are nulled out.
+      Cuts response size for large batches without changing the parser contract.
+
+    Errors are JSON-encoded ToolErrorEnvelopes with stable `code` values
+    (invalid_ip_address, no_valid_ips, too_many_ips, auth_invalid,
+    auth_insufficient_scope, quota_exceeded, timeout, api_error, unknown_error).
+
+    Note: Some fields (asn, privacy, carrier, company, abuse, domains) require
+    IPINFO_API_TOKEN with the appropriate plan tier.
+    """
+    handler, cache = _get_handler_and_cache(ctx)
+    results = await _do_batch_lookup(handler, cache, ips, ctx)
+    if detail == "summary":
+        return [_summarize_for_batch(r) for r in results]
+    return results
+
+
+@mcp.tool(
+    annotations={"readOnlyHint": True, "openWorldHint": True},
+    meta={"introduced_in": "0.5.0", "plan_required": "residential_proxy_addon"},
+    tags={"enterprise"},
+)
+async def ipinfo_check_residential_proxy(
     ip: Annotated[
         str,
         Field(
@@ -253,17 +488,17 @@ async def get_residential_proxy_info(
     ],
     ctx: Context = CurrentContext(),
 ) -> ResidentialProxyDetails:
-    """Check if an IP address is associated with a residential proxy service.
+    """Check whether an IP address belongs to a residential proxy network.
 
     Residential proxies route traffic through real residential IP addresses,
     making them harder to detect than datacenter proxies. This tool identifies
-    such IPs and provides details about the proxy service.
+    such IPs and returns details about the proxy service.
 
     Returns:
     - ip: The checked IP address
     - last_seen: Last date the proxy was active (YYYY-MM-DD)
-    - percent_days_seen: Activity percentage over the last 7 days
-    - service: Name of the residential proxy service
+    - percent_days_seen: Activity percentage over the last 7-day window
+    - service: Name of the residential proxy service (None if not a known proxy)
 
     Common use cases:
     - Fraud detection and prevention
@@ -271,11 +506,14 @@ async def get_residential_proxy_info(
     - Ad fraud analysis
     - Security investigations
 
-    Note: Requires IPINFO_API_TOKEN with residential proxy data access.
+    Errors are JSON-encoded ToolErrorEnvelopes. A 403 from IPInfo surfaces as
+    `auth_insufficient_scope` so agents can distinguish "needs a token" from
+    "token lacks the residential-proxy add-on".
+
+    Note: Requires IPINFO_API_TOKEN with the residential-proxy add-on enabled.
     """
     handler, _ = _get_handler_and_cache(ctx)
 
-    # Validate IP
     ip = ip.strip()
     _validate_ip(ip)
 
@@ -286,21 +524,20 @@ async def get_residential_proxy_info(
         return result
     except Exception as e:
         await ctx.error(f"Residential proxy lookup failed: {e}")
-        raise ToolError(f"Residential proxy lookup failed: {e}")
+        _raise_from_upstream(e)
 
 
 @mcp.tool(
-    annotations={
-        "readOnlyHint": True,
-        "openWorldHint": True,
-    }
+    annotations={"readOnlyHint": True, "openWorldHint": True},
+    meta={"introduced_in": "0.5.0"},
 )
-async def get_map_url(
+async def ipinfo_generate_map_url(
     ips: Annotated[
         list[str],
         Field(
             description="List of IP addresses to visualize on a map (IPv4 or IPv6). Maximum 500,000 IPs.",
             min_length=1,
+            max_length=MAX_LOOKUP_IPS,
             examples=[["8.8.8.8", "1.1.1.1", "208.67.222.222"]],
         ),
     ],
@@ -319,18 +556,38 @@ async def get_map_url(
 
     Returns a URL to the interactive map that can be opened in a browser.
 
-    Note: Invalid or special IPs (private, loopback, etc.) are filtered out.
+    Errors are JSON-encoded ToolErrorEnvelopes (`too_many_ips`, `no_valid_ips`,
+    upstream `api_error` / `timeout` / `unknown_error`).
+
+    Note: Invalid or special IPs (private, loopback, etc.) are filtered out
+    before the map request is sent.
     """
-    MAX_MAP_IPS = 500_000
-    if len(ips) > MAX_MAP_IPS:
-        raise ToolError(
-            f"Too many IPs ({len(ips)}). Maximum is {MAX_MAP_IPS:,} for map generation."
+    if len(ips) > MAX_LOOKUP_IPS:
+        # Schema enforces the cap, but defense-in-depth covers callers that
+        # bypass schema validation (e.g., direct Python invocation).
+        _raise_envelope(
+            "too_many_ips",
+            f"Too many IPs ({len(ips)}). Maximum is {MAX_LOOKUP_IPS:,} for map generation.",
+            temporary=False,
+            field="ips",
+            value=len(ips),
+            repair={
+                "limit": MAX_LOOKUP_IPS,
+                "received": len(ips),
+                "hint": f"Reduce ips to <= {MAX_LOOKUP_IPS} entries.",
+            },
         )
 
     valid_ips, _ = await _filter_valid_ips(ips, ctx)
 
     if not valid_ips:
-        raise ToolError("No valid IP addresses to map")
+        _raise_envelope(
+            "no_valid_ips",
+            "No valid IP addresses to map; all inputs were filtered as invalid or special-use.",
+            temporary=False,
+            field="ips",
+            repair={"hint": "Provide at least one public IPv4 or IPv6 address."},
+        )
 
     await ctx.info(f"Generating map for {len(valid_ips)} IP address(es)")
 
@@ -340,4 +597,96 @@ async def get_map_url(
         return url
     except Exception as e:
         await ctx.error(f"Map generation failed: {e}")
-        raise ToolError(f"Map generation failed: {e}")
+        _raise_from_upstream(e)
+
+
+# --- Deprecated aliases ------------------------------------------------------
+#
+# Old tool names from <= 0.4.x. They forward to the new tools so cached MCP
+# clients still work for one minor version. Removed in 0.6.0.
+
+
+@mcp.tool(
+    annotations={"readOnlyHint": True, "openWorldHint": True},
+    tags={"deprecated"},
+    meta={"deprecated_since": "0.5.0", "replaced_by": "ipinfo_lookup_ips"},
+)
+async def get_ip_details(
+    ips: Annotated[
+        list[str] | None,
+        Field(
+            description=(
+                "[DEPRECATED in 0.5.0; use ipinfo_lookup_my_ip when ips is None, "
+                "or ipinfo_lookup_ips otherwise. Removed in 0.6.0.] "
+                "IP address(es) to analyze (IPv4 or IPv6). Pass a list of one or "
+                "more IPs. If not provided, analyzes the requesting client's IP "
+                "address."
+            ),
+            examples=[["8.8.8.8"], ["8.8.8.8", "1.1.1.1", "208.67.222.222"]],
+        ),
+    ] = None,
+    ctx: Context = CurrentContext(),
+) -> list[IPDetails]:
+    """[DEPRECATED in 0.5.0 — use ipinfo_lookup_my_ip / ipinfo_lookup_ips. Removed in 0.6.0.]
+
+    Forwards to ipinfo_lookup_my_ip when called with no `ips` (or `ips=None`),
+    and to ipinfo_lookup_ips otherwise. Behavior is otherwise unchanged.
+    """
+    handler, cache = _get_handler_and_cache(ctx)
+    if ips is None:
+        return [await _do_my_ip_lookup(handler, cache, ctx)]
+    return await _do_batch_lookup(handler, cache, ips, ctx)
+
+
+@mcp.tool(
+    annotations={"readOnlyHint": True, "openWorldHint": True},
+    tags={"deprecated"},
+    meta={
+        "deprecated_since": "0.5.0",
+        "replaced_by": "ipinfo_check_residential_proxy",
+    },
+)
+async def get_residential_proxy_info(
+    ip: Annotated[
+        str,
+        Field(
+            description=(
+                "[DEPRECATED in 0.5.0; use ipinfo_check_residential_proxy. Removed "
+                "in 0.6.0.] The IP address to check for residential proxy usage "
+                "(IPv4 or IPv6)."
+            ),
+            examples=["142.250.80.46"],
+        ),
+    ],
+    ctx: Context = CurrentContext(),
+) -> ResidentialProxyDetails:
+    """[DEPRECATED in 0.5.0 — use ipinfo_check_residential_proxy. Removed in 0.6.0.]"""
+    return await ipinfo_check_residential_proxy(ip=ip, ctx=ctx)
+
+
+@mcp.tool(
+    annotations={"readOnlyHint": True, "openWorldHint": True},
+    tags={"deprecated"},
+    meta={
+        "deprecated_since": "0.5.0",
+        "replaced_by": "ipinfo_generate_map_url",
+    },
+)
+async def get_map_url(
+    ips: Annotated[
+        list[str],
+        Field(
+            description=(
+                "[DEPRECATED in 0.5.0; use ipinfo_generate_map_url. Removed in "
+                "0.6.0.] List of IP addresses to visualize on a map (IPv4 or "
+                "IPv6). Maximum 500,000 IPs."
+            ),
+            min_length=1,
+            max_length=MAX_LOOKUP_IPS,
+            examples=[["8.8.8.8", "1.1.1.1", "208.67.222.222"]],
+        ),
+    ],
+    ctx: Context = CurrentContext(),
+) -> str:
+    """[DEPRECATED in 0.5.0 — use ipinfo_generate_map_url. Removed in 0.6.0.]"""
+    return await ipinfo_generate_map_url(ips=ips, ctx=ctx)

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -1,0 +1,119 @@
+"""Tests for the structured ToolErrorEnvelope model."""
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from mcp_server_ipinfo.models import ToolErrorEnvelope
+
+
+class TestToolErrorEnvelope:
+    """Tests for ToolErrorEnvelope model.
+
+    The envelope is JSON-serialized into a ToolError message string so that
+    agents receive both isError: true on the wire AND a parseable structured
+    payload describing the failure.
+    """
+
+    def test_minimal_envelope(self):
+        """An envelope needs code, message, and temporary."""
+        env = ToolErrorEnvelope(
+            code="invalid_ip_address",
+            message="10.0.0.1 is a private IP address.",
+            temporary=False,
+        )
+        assert env.code == "invalid_ip_address"
+        assert env.message == "10.0.0.1 is a private IP address."
+        assert env.temporary is False
+        assert env.field is None
+        assert env.repair is None
+
+    def test_full_envelope(self):
+        """An envelope can carry field, value, repair, and retry_after_ms."""
+        env = ToolErrorEnvelope(
+            code="quota_exceeded",
+            message="IPInfo API quota exhausted for this token.",
+            temporary=True,
+            retry_after_ms=60_000,
+            field=None,
+            repair={"hint": "Upgrade plan or wait for daily reset."},
+        )
+        assert env.temporary is True
+        assert env.retry_after_ms == 60_000
+        assert env.repair == {"hint": "Upgrade plan or wait for daily reset."}
+
+    def test_unknown_code_rejected(self):
+        """Codes outside the documented set must fail validation."""
+        with pytest.raises(ValidationError):
+            ToolErrorEnvelope(
+                code="oopsie_doopsie",  # type: ignore[arg-type]
+                message="x",
+                temporary=False,
+            )
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "invalid_ip_address",
+            "special_ip_unsupported",
+            "no_valid_ips",
+            "too_many_ips",
+            "auth_invalid",
+            "auth_insufficient_scope",
+            "quota_exceeded",
+            "timeout",
+            "api_error",
+            "unknown_error",
+        ],
+    )
+    def test_documented_codes_accepted(self, code):
+        """Every documented code is a valid value for the code field."""
+        env = ToolErrorEnvelope(code=code, message="ok", temporary=False)
+        assert env.code == code
+
+    def test_json_roundtrip(self):
+        """An envelope serialized to JSON can be parsed back losslessly.
+
+        This is the wire shape agents will receive (encoded into a ToolError
+        message string).
+        """
+        original = ToolErrorEnvelope(
+            code="auth_insufficient_scope",
+            message="Token lacks residential-proxy access.",
+            temporary=False,
+            repair={"hint": "Enable the residential proxy add-on on your plan."},
+        )
+        wire = original.model_dump_json()
+        parsed = json.loads(wire)
+        assert parsed["code"] == "auth_insufficient_scope"
+        assert parsed["temporary"] is False
+        assert parsed["repair"]["hint"].startswith("Enable")
+        restored = ToolErrorEnvelope.model_validate_json(wire)
+        assert restored == original
+
+    def test_envelope_message_fallback_for_non_json(self):
+        """_envelope_message falls back to str() when the message isn't envelope JSON.
+
+        Defensive path: if a non-envelope ToolError ever leaks into
+        _filter_valid_ips, the warning string still surfaces something readable.
+        """
+        from fastmcp.exceptions import ToolError
+
+        from mcp_server_ipinfo.server import _envelope_message
+
+        plain = ToolError("something went wrong")
+        assert _envelope_message(plain) == "something went wrong"
+
+        # JSON without a `message` key also falls back.
+        no_message = ToolError('{"code": "x"}')
+        assert _envelope_message(no_message) == '{"code": "x"}'
+
+    def test_required_fields(self):
+        """code, message, and temporary are required."""
+        with pytest.raises(ValidationError):
+            ToolErrorEnvelope(message="x", temporary=False)  # type: ignore[call-arg]
+        with pytest.raises(ValidationError):
+            ToolErrorEnvelope(code="api_error", temporary=False)  # type: ignore[call-arg]
+        with pytest.raises(ValidationError):
+            ToolErrorEnvelope(code="api_error", message="x")  # type: ignore[call-arg]

--- a/tests/test_error_dispatch.py
+++ b/tests/test_error_dispatch.py
@@ -1,0 +1,201 @@
+"""Tests that tool errors carry a structured ToolErrorEnvelope payload.
+
+Each tool maps known upstream exception types onto stable error codes that
+agents can branch on without parsing prose.
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+from ipinfo.error import APIError
+from ipinfo.exceptions import RequestQuotaExceededError, TimeoutExceededError
+
+from mcp_server_ipinfo.server import (
+    get_ip_details,
+    get_map_url,
+    get_residential_proxy_info,
+)
+
+
+def parse_envelope(excinfo) -> dict:
+    """Parse a ToolError message back into the structured envelope dict."""
+    return json.loads(str(excinfo.value))
+
+
+class TestValidationErrorCodes:
+    """Validation failures raise ToolError with structured envelope codes."""
+
+    async def test_invalid_ip_format(self, mock_context_with_state):
+        with pytest.raises(ToolError) as excinfo:
+            await get_residential_proxy_info(
+                ip="not-an-ip", ctx=mock_context_with_state
+            )
+        env = parse_envelope(excinfo)
+        assert env["code"] == "invalid_ip_address"
+        assert env["temporary"] is False
+        assert env["field"] == "ip"
+        assert env["value"] == "not-an-ip"
+
+    async def test_private_ip_code(self, mock_context_with_state):
+        with pytest.raises(ToolError) as excinfo:
+            await get_residential_proxy_info(
+                ip="192.168.1.1", ctx=mock_context_with_state
+            )
+        env = parse_envelope(excinfo)
+        assert env["code"] == "special_ip_unsupported"
+        assert env["temporary"] is False
+        assert env["field"] == "ip"
+        # repair hint names the class of unsupported address
+        assert "private" in env["message"].lower()
+
+    async def test_no_valid_ips_code(self, mock_context_with_state):
+        with pytest.raises(ToolError) as excinfo:
+            await get_ip_details(
+                ips=["192.168.1.1", "10.0.0.1"], ctx=mock_context_with_state
+            )
+        env = parse_envelope(excinfo)
+        assert env["code"] == "no_valid_ips"
+        assert env["temporary"] is False
+        assert env["field"] == "ips"
+
+    async def test_too_many_ips_code(self, mock_context_with_state):
+        # Exceed the 500K cap to trigger the size guard.
+        ips = [f"1.1.1.{i % 256}" for i in range(500_001)]
+        with pytest.raises(ToolError) as excinfo:
+            await get_map_url(ips=ips, ctx=mock_context_with_state)
+        env = parse_envelope(excinfo)
+        assert env["code"] == "too_many_ips"
+        assert env["temporary"] is False
+        assert env["field"] == "ips"
+
+
+class TestUpstreamErrorCodes:
+    """Upstream IPInfo exceptions map onto stable, agent-actionable codes."""
+
+    async def test_api_401_to_auth_invalid(self, mock_context_with_state):
+        # APIError with HTTP 401 means the supplied token is bad.
+        with patch(
+            "mcp_server_ipinfo.server.ipinfo_lookup",
+            side_effect=APIError(401, {"error": {"message": "Wrong token"}}),
+        ):
+            with pytest.raises(ToolError) as excinfo:
+                await get_ip_details(ips=["8.8.8.8"], ctx=mock_context_with_state)
+        env = parse_envelope(excinfo)
+        assert env["code"] == "auth_invalid"
+        assert env["temporary"] is False
+        # Repair should point the agent at IPINFO_API_TOKEN.
+        assert "IPINFO_API_TOKEN" in (env["repair"] or {}).get("hint", "")
+
+    async def test_api_403_to_insufficient_scope(self, mock_context_with_state):
+        # 403 means the plan tier doesn't include the requested capability.
+        with patch(
+            "mcp_server_ipinfo.server.ipinfo_resproxy_lookup",
+            side_effect=APIError(403, {"error": {"message": "Plan required"}}),
+        ):
+            with pytest.raises(ToolError) as excinfo:
+                await get_residential_proxy_info(
+                    ip="142.250.80.46", ctx=mock_context_with_state
+                )
+        env = parse_envelope(excinfo)
+        assert env["code"] == "auth_insufficient_scope"
+        assert env["temporary"] is False
+
+    async def test_api_500_to_api_error(self, mock_context_with_state):
+        with patch(
+            "mcp_server_ipinfo.server.ipinfo_lookup",
+            side_effect=APIError(500, {"error": {"message": "boom"}}),
+        ):
+            with pytest.raises(ToolError) as excinfo:
+                await get_ip_details(ips=["8.8.8.8"], ctx=mock_context_with_state)
+        env = parse_envelope(excinfo)
+        assert env["code"] == "api_error"
+        assert env["temporary"] is True
+
+    async def test_quota_to_quota_exceeded(self, mock_context_with_state):
+        with patch(
+            "mcp_server_ipinfo.server.ipinfo_lookup",
+            side_effect=RequestQuotaExceededError(),
+        ):
+            with pytest.raises(ToolError) as excinfo:
+                await get_ip_details(ips=["8.8.8.8"], ctx=mock_context_with_state)
+        env = parse_envelope(excinfo)
+        assert env["code"] == "quota_exceeded"
+        assert env["temporary"] is True
+
+    async def test_timeout_to_timeout_code(self, mock_context_with_state):
+        with patch(
+            "mcp_server_ipinfo.server.ipinfo_lookup",
+            side_effect=TimeoutExceededError(),
+        ):
+            with pytest.raises(ToolError) as excinfo:
+                await get_ip_details(ips=["8.8.8.8"], ctx=mock_context_with_state)
+        env = parse_envelope(excinfo)
+        assert env["code"] == "timeout"
+        assert env["temporary"] is True
+
+    async def test_unknown_to_unknown_error(self, mock_context_with_state):
+        # An unexpected exception type still produces a valid envelope.
+        with patch(
+            "mcp_server_ipinfo.server.ipinfo_lookup",
+            side_effect=RuntimeError("???"),
+        ):
+            with pytest.raises(ToolError) as excinfo:
+                await get_ip_details(ips=["8.8.8.8"], ctx=mock_context_with_state)
+        env = parse_envelope(excinfo)
+        assert env["code"] == "unknown_error"
+        assert env["temporary"] is True
+
+    async def test_batch_quota_to_quota_exceeded(self, mock_context_with_state):
+        """Batch path also dispatches typed upstream errors."""
+        with patch(
+            "mcp_server_ipinfo.server.ipinfo_batch_lookup",
+            side_effect=RequestQuotaExceededError(),
+        ):
+            with pytest.raises(ToolError) as excinfo:
+                await get_ip_details(
+                    ips=["8.8.8.8", "1.1.1.1"], ctx=mock_context_with_state
+                )
+        env = parse_envelope(excinfo)
+        assert env["code"] == "quota_exceeded"
+        assert env["temporary"] is True
+
+    async def test_api_404_to_api_error_not_temporary(self, mock_context_with_state):
+        """A 4xx that isn't 401/403 lands in api_error, marked non-temporary."""
+        with patch(
+            "mcp_server_ipinfo.server.ipinfo_lookup",
+            side_effect=APIError(404, {"error": {"message": "missing"}}),
+        ):
+            with pytest.raises(ToolError) as excinfo:
+                await get_ip_details(ips=["8.8.8.8"], ctx=mock_context_with_state)
+        env = parse_envelope(excinfo)
+        assert env["code"] == "api_error"
+        assert env["temporary"] is False
+
+    async def test_my_ip_path_dispatches_upstream(self, mock_context_with_state):
+        """ipinfo_lookup_my_ip routes through the same upstream classifier."""
+        from mcp_server_ipinfo.server import ipinfo_lookup_my_ip
+
+        with patch(
+            "mcp_server_ipinfo.server.ipinfo_lookup",
+            side_effect=RequestQuotaExceededError(),
+        ):
+            with pytest.raises(ToolError) as excinfo:
+                await ipinfo_lookup_my_ip(ctx=mock_context_with_state)
+        env = parse_envelope(excinfo)
+        assert env["code"] == "quota_exceeded"
+        assert env["temporary"] is True
+
+    async def test_map_api_failure_envelope(self, mock_context_with_state):
+        with patch("mcp_server_ipinfo.ipinfo.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                side_effect=RuntimeError("network down")
+            )
+            with pytest.raises(ToolError) as excinfo:
+                await get_map_url(ips=["8.8.8.8"], ctx=mock_context_with_state)
+        env = parse_envelope(excinfo)
+        # Map errors come from httpx, not the ipinfo library — they land in
+        # the generic api_error/unknown bucket but must still be structured.
+        assert env["code"] in {"api_error", "unknown_error"}
+        assert "message" in env

--- a/tests/test_error_dispatch.py
+++ b/tests/test_error_dispatch.py
@@ -61,14 +61,40 @@ class TestValidationErrorCodes:
         assert env["field"] == "ips"
 
     async def test_too_many_ips_code(self, mock_context_with_state):
-        # Exceed the 500K cap to trigger the size guard.
-        ips = [f"1.1.1.{i % 256}" for i in range(500_001)]
+        # Exceed the 500K cap to trigger the size guard. The cap check fires
+        # before any per-IP work, so a repeated single-value list exercises
+        # the same branch with O(1) memory per element instead of O(N).
+        ips = ["1.1.1.1"] * 500_001
         with pytest.raises(ToolError) as excinfo:
             await get_map_url(ips=ips, ctx=mock_context_with_state)
         env = parse_envelope(excinfo)
         assert env["code"] == "too_many_ips"
         assert env["temporary"] is False
         assert env["field"] == "ips"
+
+    async def test_lookup_ips_defense_in_depth_cap(self, mock_context_with_state):
+        """ipinfo_lookup_ips also rejects oversized input at the runtime layer.
+
+        Schema enforces the cap at the FastMCP boundary, but direct Python
+        invocation skips that path; the inner _do_batch_lookup guard catches it.
+        """
+        from mcp_server_ipinfo.server import ipinfo_lookup_ips
+
+        ips = ["1.1.1.1"] * 500_001
+        with pytest.raises(ToolError) as excinfo:
+            await ipinfo_lookup_ips(ips=ips, ctx=mock_context_with_state)
+        env = parse_envelope(excinfo)
+        assert env["code"] == "too_many_ips"
+
+    async def test_deprecated_get_ip_details_inherits_cap(
+        self, mock_context_with_state
+    ):
+        """The deprecated alias forwards to _do_batch_lookup so it inherits the cap."""
+        ips = ["1.1.1.1"] * 500_001
+        with pytest.raises(ToolError) as excinfo:
+            await get_ip_details(ips=ips, ctx=mock_context_with_state)
+        env = parse_envelope(excinfo)
+        assert env["code"] == "too_many_ips"
 
 
 class TestUpstreamErrorCodes:

--- a/tests/test_split_tools.py
+++ b/tests/test_split_tools.py
@@ -1,0 +1,150 @@
+"""Tests for the split tools introduced in 0.5.0.
+
+`get_ip_details` is split into:
+- `ipinfo_lookup_my_ip()` — no args; the calling client's IP.
+- `ipinfo_lookup_ips(ips, detail="full")` — list lookup with optional null-stripping.
+
+The original `get_ip_details` is retained as a deprecated alias.
+"""
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from mcp_server_ipinfo.models import IPDetails
+
+
+class TestIpinfoLookupMyIp:
+    """ipinfo_lookup_my_ip() takes no arguments and returns a single IPDetails."""
+
+    async def test_returns_single_details(self, mock_context_with_state):
+        from mcp_server_ipinfo.server import ipinfo_lookup_my_ip
+
+        result = await ipinfo_lookup_my_ip(ctx=mock_context_with_state)
+        assert isinstance(result, IPDetails)
+        # The conftest mock returns 203.0.113.1 for None ip_address.
+        assert str(result.ip) == "203.0.113.1"
+
+    async def test_caches_result(self, mock_context_with_state):
+        from mcp_server_ipinfo.server import ipinfo_lookup_my_ip
+
+        cache = mock_context_with_state.lifespan_context["cache"]
+        await ipinfo_lookup_my_ip(ctx=mock_context_with_state)
+        # The IP returned by the mock should now sit in the cache.
+        cached = await cache.get("203.0.113.1")
+        assert cached is not None
+
+
+class TestIpinfoLookupIps:
+    """ipinfo_lookup_ips returns a list and supports a `detail` toggle."""
+
+    async def test_full_detail_default(self, mock_context_with_state):
+        from mcp_server_ipinfo.server import ipinfo_lookup_ips
+
+        results = await ipinfo_lookup_ips(ips=["8.8.8.8"], ctx=mock_context_with_state)
+        assert len(results) == 1
+        assert isinstance(results[0], IPDetails)
+        assert results[0].city == "Mountain View"
+
+    async def test_summary_detail_drops_heavy_blocks(
+        self, mock_context_with_state, sample_ip_details
+    ):
+        """Summary mode nulls out the heavy nested blocks for token savings.
+
+        The agent opts in by passing detail="summary"; shape parity is
+        preserved (still IPDetails) so existing parsers don't break.
+        """
+        from mcp_server_ipinfo.server import ipinfo_lookup_ips
+
+        cache = mock_context_with_state.lifespan_context["cache"]
+        # Pre-seed cache with rich IPDetails containing the heavy fields.
+        rich = sample_ip_details.model_copy(
+            update={
+                "continent": {"code": "NA", "name": "North America"},
+                "country_flag": {"emoji": "🇺🇸", "unicode": "U+1F1FA U+1F1F8"},
+                "country_currency": {"code": "USD", "symbol": "$"},
+                "isEU": False,
+            }
+        )
+        await cache.set("8.8.8.8", rich)
+
+        full = await ipinfo_lookup_ips(
+            ips=["8.8.8.8"], detail="full", ctx=mock_context_with_state
+        )
+        summary = await ipinfo_lookup_ips(
+            ips=["8.8.8.8"], detail="summary", ctx=mock_context_with_state
+        )
+
+        # Full mode preserves the heavy blocks.
+        assert full[0].continent is not None
+        assert full[0].country_flag is not None
+        # Summary mode nulls them out.
+        assert summary[0].continent is None
+        assert summary[0].country_flag is None
+        assert summary[0].country_flag_url is None
+        assert summary[0].country_currency is None
+        # Core geolocation fields survive.
+        assert summary[0].city == "Mountain View"
+        assert summary[0].country == "US"
+
+
+class TestRenamedTools:
+    """The remaining two tools are renamed with the ipinfo_ prefix."""
+
+    async def test_ipinfo_check_residential_proxy(self, mock_context_with_state):
+        from mcp_server_ipinfo.server import ipinfo_check_residential_proxy
+
+        result = await ipinfo_check_residential_proxy(
+            ip="142.250.80.46", ctx=mock_context_with_state
+        )
+        assert str(result.ip) == "142.250.80.46"
+        assert result.service == "Luminati"
+
+    async def test_ipinfo_generate_map_url(self, mock_context_with_state):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from mcp_server_ipinfo.server import ipinfo_generate_map_url
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "reportUrl": "https://ipinfo.io/map/demo/xyz"
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("mcp_server_ipinfo.ipinfo.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                return_value=mock_response
+            )
+            url = await ipinfo_generate_map_url(
+                ips=["8.8.8.8", "1.1.1.1"], ctx=mock_context_with_state
+            )
+        assert url == "https://ipinfo.io/map/demo/xyz"
+
+
+class TestDeprecatedGetIpDetails:
+    """The original get_ip_details remains as a deprecated alias."""
+
+    async def test_alias_still_callable(self, mock_context_with_state):
+        from mcp_server_ipinfo.server import get_ip_details
+
+        results = await get_ip_details(ips=["8.8.8.8"], ctx=mock_context_with_state)
+        assert len(results) == 1
+        assert str(results[0].ip) == "8.8.8.8"
+
+    async def test_alias_my_ip_mode(self, mock_context_with_state):
+        """get_ip_details(ips=None) preserves the legacy self-IP shortcut."""
+        from mcp_server_ipinfo.server import get_ip_details
+
+        results = await get_ip_details(ips=None, ctx=mock_context_with_state)
+        assert len(results) == 1
+        assert str(results[0].ip) == "203.0.113.1"
+
+    async def test_no_valid_ips_envelope(self, mock_context_with_state):
+        """The deprecated alias still emits structured envelopes on validation failures."""
+        import json
+
+        from mcp_server_ipinfo.server import get_ip_details
+
+        with pytest.raises(ToolError) as excinfo:
+            await get_ip_details(ips=["192.168.1.1"], ctx=mock_context_with_state)
+        env = json.loads(str(excinfo.value))
+        assert env["code"] == "no_valid_ips"

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -1,0 +1,87 @@
+"""Tests that the FastMCP-generated tool schemas carry our constraints.
+
+We rely on FastMCP to translate Pydantic Field(min_length=..., max_length=...)
+into JSON Schema minItems/maxItems on tool input schemas. These tests guard
+against regressions in that translation and confirm our metadata survives.
+"""
+
+import pytest
+
+
+@pytest.fixture
+async def registered_tools():
+    """Resolve the live tool registry from the FastMCP server, keyed by name."""
+    from mcp_server_ipinfo.server import mcp
+
+    tools = await mcp.list_tools()
+    return {tool.name: tool for tool in tools}
+
+
+class TestNewToolSchemas:
+    """Constraints that agents need to see in the schema."""
+
+    async def test_lookup_ips_caps_array_length(self, registered_tools):
+        tool = registered_tools["ipinfo_lookup_ips"]
+        ips_schema = tool.parameters["properties"]["ips"]
+        assert ips_schema["minItems"] == 1
+        assert ips_schema["maxItems"] == 500_000
+
+    async def test_lookup_ips_detail_is_enum(self, registered_tools):
+        tool = registered_tools["ipinfo_lookup_ips"]
+        detail_schema = tool.parameters["properties"]["detail"]
+        # Literal["summary","full"] should expose an enum constraint.
+        assert set(detail_schema.get("enum", [])) == {"summary", "full"}
+        assert detail_schema.get("default") == "full"
+
+    async def test_generate_map_url_caps_array_length(self, registered_tools):
+        tool = registered_tools["ipinfo_generate_map_url"]
+        ips_schema = tool.parameters["properties"]["ips"]
+        assert ips_schema["minItems"] == 1
+        assert ips_schema["maxItems"] == 500_000
+
+    async def test_my_ip_takes_no_args(self, registered_tools):
+        tool = registered_tools["ipinfo_lookup_my_ip"]
+        # Only the implicit Context parameter remains; no required args.
+        assert tool.parameters.get("required", []) == []
+
+
+class TestDeprecationMetadata:
+    """Deprecated aliases carry tags + meta so cached clients can detect them."""
+
+    @pytest.mark.parametrize(
+        ("name", "replacement"),
+        [
+            ("get_ip_details", "ipinfo_lookup_ips"),
+            ("get_residential_proxy_info", "ipinfo_check_residential_proxy"),
+            ("get_map_url", "ipinfo_generate_map_url"),
+        ],
+    )
+    async def test_alias_marked_deprecated(self, registered_tools, name, replacement):
+        tool = registered_tools[name]
+        assert "deprecated" in (tool.tags or set())
+        assert tool.meta is not None
+        assert tool.meta.get("deprecated_since") == "0.5.0"
+        assert tool.meta.get("replaced_by") == replacement
+
+
+class TestNewToolMetadata:
+    """New tools carry an introduced_in marker so version diffs are visible."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "ipinfo_lookup_my_ip",
+            "ipinfo_lookup_ips",
+            "ipinfo_check_residential_proxy",
+            "ipinfo_generate_map_url",
+        ],
+    )
+    async def test_introduced_in_meta(self, registered_tools, name):
+        tool = registered_tools[name]
+        assert tool.meta is not None
+        assert tool.meta.get("introduced_in") == "0.5.0"
+
+    async def test_residential_proxy_marked_enterprise(self, registered_tools):
+        tool = registered_tools["ipinfo_check_residential_proxy"]
+        assert "enterprise" in (tool.tags or set())
+        assert tool.meta.get("plan_required") == "residential_proxy_addon"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -336,7 +336,11 @@ class TestGetMapUrl:
     # API-error → structured envelope coverage lives in test_error_dispatch.py.
 
     async def test_too_many_ips_error(self, mock_context_with_state):
-        """Test error when too many IPs are provided."""
-        ips = [f"1.1.1.{i % 256}" for i in range(500_001)]
+        """Test error when too many IPs are provided.
+
+        The cap check fires before any per-IP work, so a repeated single-value
+        list keeps the test cheap.
+        """
+        ips = ["1.1.1.1"] * 500_001
         with pytest.raises(ToolError, match="Too many IPs"):
             await get_map_url(ips=ips, ctx=mock_context_with_state)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -224,25 +224,7 @@ class TestGetIPDetails:
         assert len(results) == 1
         assert str(results[0].ip) == "8.8.8.8"
 
-    async def test_api_failure(self, mock_context_with_state):
-        """Test that API failures raise ToolError."""
-        with patch(
-            "mcp_server_ipinfo.server.ipinfo_lookup",
-            side_effect=Exception("API error"),
-        ):
-            with pytest.raises(ToolError, match="Lookup failed"):
-                await get_ip_details(ips=["8.8.8.8"], ctx=mock_context_with_state)
-
-    async def test_batch_api_failure(self, mock_context_with_state):
-        """Test that batch API failures raise ToolError."""
-        with patch(
-            "mcp_server_ipinfo.server.ipinfo_batch_lookup",
-            side_effect=Exception("Batch API error"),
-        ):
-            with pytest.raises(ToolError, match="Lookup failed"):
-                await get_ip_details(
-                    ips=["8.8.8.8", "1.1.1.1"], ctx=mock_context_with_state
-                )
+    # Upstream-error → structured envelope coverage lives in test_error_dispatch.py.
 
 
 class TestGetResidentialProxyInfo:
@@ -351,14 +333,7 @@ class TestGetMapUrl:
             sent_ips = call_args.kwargs.get("json") or call_args[1].get("json")
             assert sent_ips == ["8.8.8.8"]
 
-    async def test_api_error_handling(self, mock_context_with_state):
-        """Test handling of API errors."""
-        with patch("mcp_server_ipinfo.ipinfo.httpx.AsyncClient") as mock_client:
-            mock_post = AsyncMock(side_effect=Exception("API error"))
-            mock_client.return_value.__aenter__.return_value.post = mock_post
-
-            with pytest.raises(ToolError, match="Map generation failed"):
-                await get_map_url(ips=["8.8.8.8"], ctx=mock_context_with_state)
+    # API-error → structured envelope coverage lives in test_error_dispatch.py.
 
     async def test_too_many_ips_error(self, mock_context_with_state):
         """Test error when too many IPs are provided."""

--- a/uv.lock
+++ b/uv.lock
@@ -836,7 +836,7 @@ wheels = [
 
 [[package]]
 name = "mcp-server-ipinfo"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

- **Structured error envelopes:** every `ToolError` now carries a JSON-encoded `ToolErrorEnvelope` with a stable `code`, `temporary` flag, optional `retry_after_ms`, and `repair` hint. `APIError` is dispatched by HTTP status (401 → `auth_invalid`, 403 → `auth_insufficient_scope`, 5xx → temporary `api_error`); `RequestQuotaExceededError` and `TimeoutExceededError` get their own codes.
- **`get_ip_details` split** into `ipinfo_lookup_my_ip()` (no args, self-IP) and `ipinfo_lookup_ips(ips, detail="full")` with schema-enforced `min_length=1, max_length=500_000`. `detail="summary"` nulls the heavy nested blocks (`continent`, `country_flag*`, `country_currency`, `abuse`, `domains`) while preserving `IPDetails` shape parity.
- **Renamed** `get_residential_proxy_info` → `ipinfo_check_residential_proxy` (tagged `enterprise` with `meta.plan_required = "residential_proxy_addon"`) and `get_map_url` → `ipinfo_generate_map_url`.
- **Deprecation aliases:** `get_ip_details`, `get_residential_proxy_info`, `get_map_url` remain as forwarding wrappers tagged `deprecated` with `meta.replaced_by` set; **scheduled for removal in 0.6.0**.

## Why

Audit ([agent-friendly-mcp skill](../.claude/skills/agent-friendly-mcp)) found six Major and one Critical agent-friendliness gap, concentrated in §6 (failure recovery) and §3 (tool granularity). Agents had no way to distinguish a missing token from an insufficient plan tier from a quota error — all three collapsed to one opaque `ToolError("Lookup failed: ...")`. The `get_ip_details(ips=None)` mode-switch hid a self-IP shortcut that the schema couldn't express. This PR closes those gaps.

## Test plan

- [x] `uv run pytest` — 134 tests pass (up from 86)
- [x] Coverage 98.42% (up from 96.26%; 95% gate)
- [x] `uv run ruff check` clean
- [x] `uv run ty check` clean
- [x] New test files exercise: envelope shape & JSON roundtrip (`test_envelope.py`), every error code per tool with mocked `APIError`/`RequestQuotaExceededError`/`TimeoutExceededError` (`test_error_dispatch.py`), split-tool behavior including `detail` toggle (`test_split_tools.py`), and FastMCP-generated schema introspection asserting `maxItems`, `enum`, `tags`, and `meta` survive registration (`test_tool_schemas.py`)
- [x] Backwards compatibility: deprecated aliases tested for both modes (`get_ip_details(ips=None)`, `get_ip_details(ips=[...])`) and still emit structured envelopes on validation failures
- [ ] Manual smoke test against a live IPInfo token (recommended before merge)

## Follow-ups (planned in subsequent PRs)

- **PR 2:** Structured `MapResult` (`url, mapped_ip_count, skipped_ips, truncated`) replacing the bare URL string; explicit `httpx.AsyncClient(timeout=...)` and `@mcp.tool(timeout=...)` on the map tool.
- **PR 3:** Expanded `instructions` with negative scope and cache documentation; derived `is_residential_proxy: bool` field on `ResidentialProxyDetails`; consolidated `IPINFO_API_TOKEN` reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)