### PR TITLE
Structured MapResult, httpx exception classification, map-tool timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Server `instructions` document the structured error contract and list both current and deprecated tool names
 
 ### Deprecated
-- `get_ip_details`, `get_residential_proxy_info`, `get_map_url` retained as forwarding aliases tagged `deprecated` with `meta.replaced_by`; **scheduled for removal in 0.6.0**
+- `get_ip_details`, `get_residential_proxy_info`, `get_map_url` retained as forwarding aliases tagged `deprecated` with `meta.replaced_by`; **scheduled for removal in 0.6.0**. The `get_map_url` alias preserves the bare-URL `str` return shape from 0.4.x; new code should call `ipinfo_generate_map_url` directly to receive the structured `MapResult`.
+
+### Changed (continued)
+- **Breaking for `ipinfo_generate_map_url`:** the tool now returns a structured `MapResult` (`url`, `mapped_ip_count`, `skipped_ips`, `skipped_count`, `truncated`) instead of a bare URL string. Agents see how many of the submitted IPs made the map and which were filtered out, with a per-IP reason. `skipped_ips` is capped at 100 entries; `truncated=True` signals overflow. The deprecated `get_map_url` alias still returns just the URL string for cached-client parity.
+
+### Added (continued)
+- `MapResult` and `SkippedIP` Pydantic models for the structured map response
+- httpx exception classification: `httpx.TimeoutException` → `timeout` envelope code, `httpx.HTTPStatusError` → status-aware codes (`auth_invalid` for 401, `auth_insufficient_scope` for 403, `quota_exceeded` for 429, `api_error` for other 4xx/5xx)
+- Explicit timeouts on the map path: `httpx.AsyncClient(timeout=30s)` at the HTTP layer plus FastMCP's `@mcp.tool(timeout=60s)` as framework-level defense-in-depth so a hung upstream cannot block the tool indefinitely
 
 ## [0.4.0] - 2026-04-11
 

--- a/src/mcp_server_ipinfo/ipinfo.py
+++ b/src/mcp_server_ipinfo/ipinfo.py
@@ -146,7 +146,12 @@ async def ipinfo_resproxy_lookup(
     )
 
 
-async def ipinfo_get_map_url(ips: list[str]) -> str:
+DEFAULT_MAP_TIMEOUT_SECONDS = 30.0
+
+
+async def ipinfo_get_map_url(
+    ips: list[str], timeout: float = DEFAULT_MAP_TIMEOUT_SECONDS
+) -> str:
     """
     Get a URL to an interactive map visualization of IP addresses.
 
@@ -154,12 +159,15 @@ async def ipinfo_get_map_url(ips: list[str]) -> str:
 
     Args:
         ips: List of IP address strings to visualize on the map.
+        timeout: Request timeout in seconds. Bounds the HTTP call so a hung
+            upstream cannot block the tool indefinitely.
 
     Returns:
         URL to the interactive map.
 
     Raises:
         httpx.HTTPStatusError: If the API request fails.
+        httpx.TimeoutException: If the request exceeds ``timeout``.
     """
     headers = {
         "content-type": "application/json",
@@ -169,7 +177,7 @@ async def ipinfo_get_map_url(ips: list[str]) -> str:
     if token:
         headers["Authorization"] = f"Bearer {token}"
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=timeout) as client:
         response = await client.post(
             f"{IPINFO_API_URL}/map?cli=1",
             json=ips,

--- a/src/mcp_server_ipinfo/models.py
+++ b/src/mcp_server_ipinfo/models.py
@@ -337,3 +337,37 @@ class IPDetails(BaseModel):
     # Metadata
     ts_retrieved: str | None = None
     """Timestamp when this lookup was performed (UTC ISO format)"""
+
+
+class SkippedIP(BaseModel):
+    """A single input IP that was filtered out before reaching the upstream API."""
+
+    ip: str
+    """The original input string (preserved before normalization for traceability)."""
+
+    reason: str
+    """Readable explanation (e.g., 'private IP address. Geolocation is not available.')."""
+
+
+class MapResult(BaseModel):
+    """Structured response from ``ipinfo_generate_map_url``.
+
+    Replaces the bare-URL string return so agents can see how many of the
+    submitted IPs actually made the map, and which were filtered out (with
+    reasons), without re-validating client-side.
+    """
+
+    url: HttpUrl
+    """URL of the interactive map on ipinfo.io."""
+
+    mapped_ip_count: int
+    """Number of IPs that made it onto the map (after dedup, normalization, and validation)."""
+
+    skipped_ips: list[SkippedIP] = Field(default_factory=list)
+    """Per-IP filter reasons. Capped at 100 entries; ``truncated`` indicates overflow."""
+
+    skipped_count: int
+    """Total number of IPs filtered out, even when ``skipped_ips`` is truncated."""
+
+    truncated: bool
+    """True when ``skipped_ips`` was capped at 100 because more were filtered."""

--- a/src/mcp_server_ipinfo/server.py
+++ b/src/mcp_server_ipinfo/server.py
@@ -118,6 +118,11 @@ MAX_LOOKUP_IPS = 500_000
 # entries filtered cannot inflate the response. truncated=True signals overflow.
 MAX_SKIPPED_IPS_REPORTED = 100
 
+# Cap on per-IP ``ctx.warning`` emissions during input filtering so a 500K
+# batch with many filtered entries cannot drown the log stream (and trip the
+# tool-level timeout). After the cap, a single aggregated summary is logged.
+MAX_SKIP_WARNINGS = 100
+
 # Framework-level guard on the map tool. Bounds end-to-end execution time
 # even if the underlying httpx client misbehaves; httpx itself enforces a
 # tighter per-request timeout (DEFAULT_MAP_TIMEOUT_SECONDS).
@@ -359,7 +364,12 @@ async def _filter_valid_ips(
     """Normalize, deduplicate, validate IPs and log warnings for skipped ones.
 
     Returns:
-        A tuple of (valid_ips, skipped) where skipped contains (ip, reason) pairs.
+        A tuple of (valid_ips, skipped) where skipped contains (ip, reason)
+        pairs. Empty/placeholder values and duplicates are recorded in
+        ``skipped`` with explicit reasons so ``mapped + skipped`` accounts for
+        every input. Per-IP ``ctx.warning`` emissions are capped at
+        ``MAX_SKIP_WARNINGS`` (with an aggregated summary after the cap) so a
+        500K batch cannot flood the log stream.
     """
     seen: set[str] = set()
     valid: list[str] = []
@@ -367,7 +377,11 @@ async def _filter_valid_ips(
 
     for ip in ips:
         norm = _normalize_ip(ip)
-        if norm is None or norm in seen:
+        if norm is None:
+            skipped.append((ip, "empty or placeholder value (treated as not an IP)"))
+            continue
+        if norm in seen:
+            skipped.append((ip, "duplicate of a previously submitted IP"))
             continue
         seen.add(norm)
 
@@ -377,8 +391,14 @@ async def _filter_valid_ips(
         except ToolError as e:
             skipped.append((ip, _envelope_message(e)))
 
-    for ip, reason in skipped:
+    for ip, reason in skipped[:MAX_SKIP_WARNINGS]:
         await ctx.warning(f"Skipping {ip}: {reason}")
+    if len(skipped) > MAX_SKIP_WARNINGS:
+        await ctx.warning(
+            f"Skipped {len(skipped)} IPs total; per-IP details logged for the first "
+            f"{MAX_SKIP_WARNINGS}. The structured response carries up to "
+            f"{MAX_SKIPPED_IPS_REPORTED} skipped entries with reasons."
+        )
 
     return valid, skipped
 

--- a/src/mcp_server_ipinfo/server.py
+++ b/src/mcp_server_ipinfo/server.py
@@ -4,6 +4,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Annotated, Any, Literal, NoReturn
 
+import httpx
 import ipinfo
 from fastmcp import Context, FastMCP
 from fastmcp.dependencies import CurrentContext
@@ -20,7 +21,14 @@ from .ipinfo import (
     ipinfo_lookup,
     ipinfo_resproxy_lookup,
 )
-from .models import IPDetails, ResidentialProxyDetails, ToolErrorCode, ToolErrorEnvelope
+from .models import (
+    IPDetails,
+    MapResult,
+    ResidentialProxyDetails,
+    SkippedIP,
+    ToolErrorCode,
+    ToolErrorEnvelope,
+)
 
 
 @asynccontextmanager
@@ -47,7 +55,7 @@ mcp = FastMCP(
     - ipinfo_lookup_my_ip: Look up details for the calling client's own IP address
     - ipinfo_lookup_ips: Look up details for one or more specific IPs (supports detail="summary" for batch token savings)
     - ipinfo_check_residential_proxy: Check if an IP belongs to a residential proxy network
-    - ipinfo_generate_map_url: Generate an interactive map URL for a set of IP locations
+    - ipinfo_generate_map_url: Generate an interactive map URL for a set of IP locations (returns a structured MapResult)
 
     Deprecated aliases (will be removed in 0.6.0): get_ip_details, get_residential_proxy_info, get_map_url.
 
@@ -106,6 +114,15 @@ DetailLevel = Literal["summary", "full"]
 
 MAX_LOOKUP_IPS = 500_000
 
+# Cap on the size of MapResult.skipped_ips so a 500K-IP submission with all
+# entries filtered cannot inflate the response. truncated=True signals overflow.
+MAX_SKIPPED_IPS_REPORTED = 100
+
+# Framework-level guard on the map tool. Bounds end-to-end execution time
+# even if the underlying httpx client misbehaves; httpx itself enforces a
+# tighter per-request timeout (DEFAULT_MAP_TIMEOUT_SECONDS).
+MAP_TOOL_TIMEOUT_SECONDS = 60.0
+
 
 def _raise_envelope(
     code: ToolErrorCode,
@@ -140,8 +157,9 @@ def _envelope_from_upstream(
     """Classify an upstream exception into the structured-error fields.
 
     Returns ``(code, message, temporary, retry_after_ms, repair)``. The mapping
-    distinguishes auth failures from quota and timeout failures so agents can
-    take different repair paths.
+    covers both the ``ipinfo`` SDK exceptions (used by the lookup tools) and
+    raw ``httpx`` exceptions (used by the map tool which calls the IPInfo map
+    endpoint directly).
     """
     if isinstance(exc, APIError):
         if exc.error_code == 401:
@@ -202,6 +220,59 @@ def _envelope_from_upstream(
             True,
             None,
             {"hint": "Retry; transient network or upstream slowness."},
+        )
+    # The map tool talks to ipinfo.io via httpx directly, so its failures
+    # surface as httpx exceptions rather than ipinfo SDK exceptions.
+    if isinstance(exc, httpx.TimeoutException):
+        return (
+            "timeout",
+            "Map request timed out before the upstream responded.",
+            True,
+            None,
+            {"hint": "Retry; transient network or upstream slowness."},
+        )
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = exc.response.status_code
+        if status == 401:
+            return (
+                "auth_invalid",
+                "IPInfo rejected the provided API token.",
+                False,
+                None,
+                {"hint": "Set IPINFO_API_TOKEN to a valid IPInfo API token."},
+            )
+        if status == 403:
+            return (
+                "auth_insufficient_scope",
+                "IPInfo plan does not grant access to the map endpoint.",
+                False,
+                None,
+                {"hint": "Upgrade your IPInfo plan."},
+            )
+        if status == 429:
+            return (
+                "quota_exceeded",
+                "IPInfo rate limit exceeded.",
+                True,
+                None,
+                {"hint": "Wait for the rate-limit window to reset."},
+            )
+        if 500 <= status < 600:
+            return (
+                "api_error",
+                f"IPInfo returned HTTP {status}.",
+                True,
+                None,
+                {
+                    "hint": "Retry after a short delay; the upstream service is degraded."
+                },
+            )
+        return (
+            "api_error",
+            f"IPInfo returned HTTP {status}.",
+            False,
+            None,
+            None,
         )
     # Catch-all: surface the exception class name as a structured field so
     # agents can branch on type without parsing the message. The raw
@@ -411,6 +482,15 @@ async def _do_batch_lookup(
     return ordered_results
 
 
+def _build_skipped_list(
+    skipped: list[tuple[str, str]],
+) -> tuple[list[SkippedIP], bool]:
+    """Convert filter results into a capped SkippedIP list plus a truncation flag."""
+    truncated = len(skipped) > MAX_SKIPPED_IPS_REPORTED
+    capped = skipped[:MAX_SKIPPED_IPS_REPORTED]
+    return [SkippedIP(ip=ip, reason=reason) for ip, reason in capped], truncated
+
+
 @mcp.tool(
     annotations={"readOnlyHint": True, "openWorldHint": True},
     meta={"introduced_in": "0.5.0"},
@@ -552,6 +632,7 @@ async def ipinfo_check_residential_proxy(
 @mcp.tool(
     annotations={"readOnlyHint": True, "openWorldHint": True},
     meta={"introduced_in": "0.5.0"},
+    timeout=MAP_TOOL_TIMEOUT_SECONDS,
 )
 async def ipinfo_generate_map_url(
     ips: Annotated[
@@ -564,11 +645,12 @@ async def ipinfo_generate_map_url(
         ),
     ],
     ctx: Context = CurrentContext(),
-) -> str:
-    """Generate a URL to an interactive map visualization of IP addresses.
+) -> MapResult:
+    """Generate an interactive map visualization for a set of IP addresses.
 
-    Creates a map on ipinfo.io showing the geographic locations of the provided
-    IP addresses. The map is interactive and can be shared.
+    Submits the IPs to ipinfo.io's map endpoint and returns a structured
+    MapResult containing the URL, the count that made the map, the IPs that
+    were filtered out (with reasons), and a truncation flag.
 
     Common use cases:
     - Visualize geographic distribution of server logs
@@ -576,13 +658,17 @@ async def ipinfo_generate_map_url(
     - Display IP address clusters for security analysis
     - Geographic visualization of network traffic
 
-    Returns a URL to the interactive map that can be opened in a browser.
+    Response shape (MapResult):
+    - url: HttpUrl to the interactive map
+    - mapped_ip_count: Number of IPs that made it onto the map
+    - skipped_ips: List of (ip, reason) entries for inputs that were filtered;
+      capped at 100 entries
+    - skipped_count: Total filtered count, even when the list is truncated
+    - truncated: True when skipped_ips was capped
 
     Errors are JSON-encoded ToolErrorEnvelopes (`too_many_ips`, `no_valid_ips`,
-    upstream `api_error` / `timeout` / `unknown_error`).
-
-    Note: Invalid or special IPs (private, loopback, etc.) are filtered out
-    before the map request is sent.
+    upstream `api_error` / `timeout` / `auth_invalid` / `auth_insufficient_scope`
+    / `quota_exceeded` / `unknown_error`).
     """
     if len(ips) > MAX_LOOKUP_IPS:
         # Schema enforces the cap, but defense-in-depth covers callers that
@@ -600,7 +686,7 @@ async def ipinfo_generate_map_url(
             },
         )
 
-    valid_ips, _ = await _filter_valid_ips(ips, ctx)
+    valid_ips, skipped = await _filter_valid_ips(ips, ctx)
 
     if not valid_ips:
         _raise_envelope(
@@ -608,7 +694,10 @@ async def ipinfo_generate_map_url(
             "No valid IP addresses to map; all inputs were filtered as invalid or special-use.",
             temporary=False,
             field="ips",
-            repair={"hint": "Provide at least one public IPv4 or IPv6 address."},
+            repair={
+                "hint": "Provide at least one public IPv4 or IPv6 address.",
+                "skipped_count": len(skipped),
+            },
         )
 
     await ctx.info(f"Generating map for {len(valid_ips)} IP address(es)")
@@ -616,10 +705,20 @@ async def ipinfo_generate_map_url(
     try:
         url = await ipinfo_get_map_url(valid_ips)
         await ctx.info("Map URL generated successfully")
-        return url
     except Exception as e:
         await ctx.error(f"Map generation failed: {e}")
         _raise_from_upstream(e)
+
+    skipped_entries, truncated = _build_skipped_list(skipped)
+    return MapResult.model_validate(
+        {
+            "url": url,
+            "mapped_ip_count": len(valid_ips),
+            "skipped_ips": skipped_entries,
+            "skipped_count": len(skipped),
+            "truncated": truncated,
+        }
+    )
 
 
 # --- Deprecated aliases ------------------------------------------------------
@@ -710,5 +809,11 @@ async def get_map_url(
     ],
     ctx: Context = CurrentContext(),
 ) -> str:
-    """[DEPRECATED in 0.5.0 — use ipinfo_generate_map_url. Removed in 0.6.0.]"""
-    return await ipinfo_generate_map_url(ips=ips, ctx=ctx)
+    """[DEPRECATED in 0.5.0 — use ipinfo_generate_map_url. Removed in 0.6.0.]
+
+    Returns just the bare map URL string for 0.4.x cached-client parity.
+    Callers wanting structured skip/truncation metadata should call
+    ipinfo_generate_map_url directly.
+    """
+    result = await ipinfo_generate_map_url(ips=ips, ctx=ctx)
+    return str(result.url)

--- a/tests/test_map_result.py
+++ b/tests/test_map_result.py
@@ -109,6 +109,76 @@ class TestIpinfoGenerateMapUrlReturnsStructured:
             assert "private" in entry.reason.lower()
         assert result.truncated is False
 
+    async def test_sentinels_recorded_as_skipped(
+        self, mock_context_with_state, mock_httpx_response
+    ):
+        """Empty/placeholder inputs ("", "null", "0.0.0.0") show up in skipped_count.
+
+        Regression for accounting: mapped_ip_count + skipped_count must equal
+        the input length so agents can audit what happened to every IP they sent.
+        """
+        from mcp_server_ipinfo.server import ipinfo_generate_map_url
+
+        ips = ["8.8.8.8", "", "null", "undefined", "0.0.0.0", "1.1.1.1"]
+        with patch("mcp_server_ipinfo.ipinfo.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                return_value=mock_httpx_response
+            )
+            result = await ipinfo_generate_map_url(ips=ips, ctx=mock_context_with_state)
+
+        assert result.mapped_ip_count == 2
+        assert result.skipped_count == 4
+        assert result.mapped_ip_count + result.skipped_count == len(ips)
+        # Each sentinel surfaces with a readable reason.
+        sentinel_reasons = {entry.ip: entry.reason for entry in result.skipped_ips}
+        for sentinel in ("", "null", "undefined", "0.0.0.0"):
+            assert sentinel in sentinel_reasons
+            assert "placeholder" in sentinel_reasons[sentinel]
+
+    async def test_duplicates_recorded_as_skipped(
+        self, mock_context_with_state, mock_httpx_response
+    ):
+        """Duplicate inputs are counted in skipped, not silently dropped."""
+        from mcp_server_ipinfo.server import ipinfo_generate_map_url
+
+        ips = ["8.8.8.8", "8.8.8.8", "1.1.1.1", "8.8.8.8"]
+        with patch("mcp_server_ipinfo.ipinfo.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                return_value=mock_httpx_response
+            )
+            result = await ipinfo_generate_map_url(ips=ips, ctx=mock_context_with_state)
+
+        assert result.mapped_ip_count == 2
+        assert result.skipped_count == 2
+        for entry in result.skipped_ips:
+            assert entry.ip == "8.8.8.8"
+            assert "duplicate" in entry.reason.lower()
+
+    async def test_warning_emissions_capped(
+        self, mock_context_with_state, mock_httpx_response
+    ):
+        """Per-IP ctx.warning() emissions stop at MAX_SKIP_WARNINGS + 1 (summary)."""
+        from mcp_server_ipinfo.server import (
+            MAX_SKIP_WARNINGS,
+            ipinfo_generate_map_url,
+        )
+
+        # 200 private IPs (all skipped) + 1 public so the call doesn't error out.
+        ips = [f"10.0.{i // 256}.{i % 256}" for i in range(200)] + ["8.8.8.8"]
+        with patch("mcp_server_ipinfo.ipinfo.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                return_value=mock_httpx_response
+            )
+            await ipinfo_generate_map_url(ips=ips, ctx=mock_context_with_state)
+
+        # MAX_SKIP_WARNINGS per-IP warnings + one aggregated summary warning.
+        warning_count = mock_context_with_state.warning.call_count
+        assert warning_count == MAX_SKIP_WARNINGS + 1
+        # The last call is the aggregated summary.
+        summary = mock_context_with_state.warning.call_args.args[0]
+        assert "200" in summary  # total skipped
+        assert str(MAX_SKIP_WARNINGS) in summary
+
     async def test_skipped_list_caps_at_100(
         self, mock_context_with_state, mock_httpx_response
     ):

--- a/tests/test_map_result.py
+++ b/tests/test_map_result.py
@@ -1,0 +1,283 @@
+"""Tests for the structured MapResult response shape (introduced in 0.5.x).
+
+`ipinfo_generate_map_url` now returns a typed MapResult with the URL, the
+count that made the map, the list of IPs filtered out, and a truncated flag.
+The deprecated `get_map_url` alias keeps the bare `str` return shape for
+0.4.x cached-client parity.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastmcp.exceptions import ToolError
+
+from mcp_server_ipinfo.models import MapResult, SkippedIP
+
+
+def parse_envelope(excinfo) -> dict:
+    import json
+
+    return json.loads(str(excinfo.value))
+
+
+@pytest.fixture
+def mock_httpx_response():
+    """A successful map-API response."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"reportUrl": "https://ipinfo.io/map/demo/abc123"}
+    mock_response.raise_for_status = MagicMock()
+    return mock_response
+
+
+class TestMapResultModel:
+    """The MapResult model carries everything an agent needs to act on."""
+
+    def test_required_fields(self):
+        result = MapResult(
+            url="https://ipinfo.io/map/demo/x",
+            mapped_ip_count=2,
+            skipped_ips=[],
+            skipped_count=0,
+            truncated=False,
+        )
+        assert result.mapped_ip_count == 2
+        assert result.truncated is False
+        assert str(result.url) == "https://ipinfo.io/map/demo/x"
+
+    def test_skipped_entry_shape(self):
+        entry = SkippedIP(ip="192.168.1.1", reason="private IP address")
+        assert entry.ip == "192.168.1.1"
+        assert "private" in entry.reason
+
+    def test_truncation_flag(self):
+        many = [SkippedIP(ip=f"10.0.0.{i}", reason="private") for i in range(100)]
+        result = MapResult(
+            url="https://ipinfo.io/map/demo/x",
+            mapped_ip_count=5,
+            skipped_ips=many,
+            skipped_count=250,  # actual total exceeded the 100 cap
+            truncated=True,
+        )
+        assert result.truncated is True
+        assert len(result.skipped_ips) == 100
+        assert result.skipped_count == 250
+
+
+class TestIpinfoGenerateMapUrlReturnsStructured:
+    """ipinfo_generate_map_url returns a MapResult, not a bare URL string."""
+
+    async def test_returns_map_result(
+        self, mock_context_with_state, mock_httpx_response
+    ):
+        from mcp_server_ipinfo.server import ipinfo_generate_map_url
+
+        with patch("mcp_server_ipinfo.ipinfo.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                return_value=mock_httpx_response
+            )
+            result = await ipinfo_generate_map_url(
+                ips=["8.8.8.8", "1.1.1.1"], ctx=mock_context_with_state
+            )
+
+        assert isinstance(result, MapResult)
+        assert str(result.url) == "https://ipinfo.io/map/demo/abc123"
+        assert result.mapped_ip_count == 2
+        assert result.skipped_ips == []
+        assert result.skipped_count == 0
+        assert result.truncated is False
+
+    async def test_skipped_ips_recorded(
+        self, mock_context_with_state, mock_httpx_response
+    ):
+        """Invalid IPs surface as structured SkippedIP entries with readable reasons."""
+        from mcp_server_ipinfo.server import ipinfo_generate_map_url
+
+        with patch("mcp_server_ipinfo.ipinfo.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                return_value=mock_httpx_response
+            )
+            result = await ipinfo_generate_map_url(
+                ips=["8.8.8.8", "192.168.1.1", "10.0.0.1", "1.1.1.1"],
+                ctx=mock_context_with_state,
+            )
+
+        assert result.mapped_ip_count == 2
+        assert result.skipped_count == 2
+        assert {entry.ip for entry in result.skipped_ips} == {"192.168.1.1", "10.0.0.1"}
+        for entry in result.skipped_ips:
+            assert "private" in entry.reason.lower()
+        assert result.truncated is False
+
+    async def test_skipped_list_caps_at_100(
+        self, mock_context_with_state, mock_httpx_response
+    ):
+        """When more than 100 IPs are skipped, the list truncates and the flag fires.
+
+        skipped_count must reflect the *actual* total even when the list is capped.
+        """
+        from mcp_server_ipinfo.server import ipinfo_generate_map_url
+
+        # 150 private + 1 public IP. All 150 should be filtered, but only 100
+        # should appear in the SkippedIP list.
+        ips = [f"10.0.{i // 256}.{i % 256}" for i in range(150)] + ["8.8.8.8"]
+        with patch("mcp_server_ipinfo.ipinfo.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                return_value=mock_httpx_response
+            )
+            result = await ipinfo_generate_map_url(ips=ips, ctx=mock_context_with_state)
+
+        assert result.mapped_ip_count == 1
+        assert result.skipped_count == 150
+        assert len(result.skipped_ips) == 100
+        assert result.truncated is True
+
+
+class TestDeprecatedGetMapUrlPreservesStringReturn:
+    """The deprecated get_map_url alias keeps the 0.4.x bare-URL return shape."""
+
+    async def test_alias_returns_string(
+        self, mock_context_with_state, mock_httpx_response
+    ):
+        from mcp_server_ipinfo.server import get_map_url
+
+        with patch("mcp_server_ipinfo.ipinfo.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                return_value=mock_httpx_response
+            )
+            url = await get_map_url(ips=["8.8.8.8"], ctx=mock_context_with_state)
+
+        assert isinstance(url, str)
+        assert url == "https://ipinfo.io/map/demo/abc123"
+
+
+class TestHttpxErrorClassification:
+    """httpx exceptions from the map call route through the structured envelope."""
+
+    async def test_timeout_to_timeout_code(self, mock_context_with_state):
+        from mcp_server_ipinfo.server import ipinfo_generate_map_url
+
+        with patch("mcp_server_ipinfo.ipinfo.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                side_effect=httpx.TimeoutException("upstream slow")
+            )
+            with pytest.raises(ToolError) as excinfo:
+                await ipinfo_generate_map_url(
+                    ips=["8.8.8.8"], ctx=mock_context_with_state
+                )
+
+        env = parse_envelope(excinfo)
+        assert env["code"] == "timeout"
+        assert env["temporary"] is True
+
+    async def test_http_500_to_temporary_api_error(self, mock_context_with_state):
+        from mcp_server_ipinfo.server import ipinfo_generate_map_url
+
+        # raise_for_status raises HTTPStatusError on 500.
+        bad_response = MagicMock()
+        bad_response.status_code = 500
+        bad_response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "Server error",
+                request=MagicMock(),
+                response=MagicMock(status_code=500),
+            )
+        )
+        with patch("mcp_server_ipinfo.ipinfo.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                return_value=bad_response
+            )
+            with pytest.raises(ToolError) as excinfo:
+                await ipinfo_generate_map_url(
+                    ips=["8.8.8.8"], ctx=mock_context_with_state
+                )
+
+        env = parse_envelope(excinfo)
+        assert env["code"] == "api_error"
+        assert env["temporary"] is True
+
+    @pytest.mark.parametrize(
+        ("status_code", "expected_code", "expected_temporary"),
+        [
+            (401, "auth_invalid", False),
+            (403, "auth_insufficient_scope", False),
+            (429, "quota_exceeded", True),
+        ],
+        ids=["401", "403", "429"],
+    )
+    async def test_http_status_dispatch(
+        self,
+        mock_context_with_state,
+        status_code,
+        expected_code,
+        expected_temporary,
+    ):
+        """Map-endpoint status codes route to the same envelope codes as the SDK exceptions."""
+        from mcp_server_ipinfo.server import ipinfo_generate_map_url
+
+        bad_response = MagicMock()
+        bad_response.status_code = status_code
+        bad_response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                f"HTTP {status_code}",
+                request=MagicMock(),
+                response=MagicMock(status_code=status_code),
+            )
+        )
+        with patch("mcp_server_ipinfo.ipinfo.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                return_value=bad_response
+            )
+            with pytest.raises(ToolError) as excinfo:
+                await ipinfo_generate_map_url(
+                    ips=["8.8.8.8"], ctx=mock_context_with_state
+                )
+
+        env = parse_envelope(excinfo)
+        assert env["code"] == expected_code
+        assert env["temporary"] is expected_temporary
+
+    async def test_http_404_to_non_temporary_api_error(self, mock_context_with_state):
+        from mcp_server_ipinfo.server import ipinfo_generate_map_url
+
+        bad_response = MagicMock()
+        bad_response.status_code = 404
+        bad_response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "Not found",
+                request=MagicMock(),
+                response=MagicMock(status_code=404),
+            )
+        )
+        with patch("mcp_server_ipinfo.ipinfo.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                return_value=bad_response
+            )
+            with pytest.raises(ToolError) as excinfo:
+                await ipinfo_generate_map_url(
+                    ips=["8.8.8.8"], ctx=mock_context_with_state
+                )
+
+        env = parse_envelope(excinfo)
+        assert env["code"] == "api_error"
+        assert env["temporary"] is False
+
+
+class TestHttpxClientTimeout:
+    """The httpx.AsyncClient is constructed with an explicit timeout."""
+
+    async def test_async_client_passes_timeout(
+        self, mock_context_with_state, mock_httpx_response
+    ):
+        from mcp_server_ipinfo.server import ipinfo_generate_map_url
+
+        with patch("mcp_server_ipinfo.ipinfo.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                return_value=mock_httpx_response
+            )
+            await ipinfo_generate_map_url(ips=["8.8.8.8"], ctx=mock_context_with_state)
+
+        # AsyncClient must be called with a non-None timeout argument.
+        kwargs = mock_client.call_args.kwargs
+        assert "timeout" in kwargs
+        assert kwargs["timeout"] is not None

--- a/tests/test_split_tools.py
+++ b/tests/test_split_tools.py
@@ -102,6 +102,7 @@ class TestRenamedTools:
     async def test_ipinfo_generate_map_url(self, mock_context_with_state):
         from unittest.mock import AsyncMock, MagicMock, patch
 
+        from mcp_server_ipinfo.models import MapResult
         from mcp_server_ipinfo.server import ipinfo_generate_map_url
 
         mock_response = MagicMock()
@@ -114,10 +115,12 @@ class TestRenamedTools:
             mock_client.return_value.__aenter__.return_value.post = AsyncMock(
                 return_value=mock_response
             )
-            url = await ipinfo_generate_map_url(
+            result = await ipinfo_generate_map_url(
                 ips=["8.8.8.8", "1.1.1.1"], ctx=mock_context_with_state
             )
-        assert url == "https://ipinfo.io/map/demo/xyz"
+        assert isinstance(result, MapResult)
+        assert str(result.url) == "https://ipinfo.io/map/demo/xyz"
+        assert result.mapped_ip_count == 2
 
 
 class TestDeprecatedGetIpDetails:


### PR DESCRIPTION
## Summary

- **`ipinfo_generate_map_url` now returns a structured `MapResult`** (`url`, `mapped_ip_count`, `skipped_ips`, `skipped_count`, `truncated`) instead of a bare URL string. Agents can see how many IPs made the map and which were filtered out, with a per-IP reason. `skipped_ips` caps at 100 entries; `truncated=True` signals overflow. The deprecated `get_map_url` alias keeps the bare-URL `str` return for 0.4.x cached-client parity.
- **httpx exception classification** added to `_envelope_from_upstream`: the map tool talks to ipinfo.io via httpx directly (not the SDK), so its failures previously fell through to `unknown_error`. Now `httpx.TimeoutException` → `timeout`, and `httpx.HTTPStatusError` → status-aware codes (`auth_invalid` 401, `auth_insufficient_scope` 403, `quota_exceeded` 429, `api_error` for other 4xx/5xx with the same temporary/non-temporary split as `APIError`).
- **Defense-in-depth timeouts** on the map path: `httpx.AsyncClient(timeout=30s)` at the HTTP layer plus FastMCP's `@mcp.tool(timeout=60s)` so a hung upstream cannot block the tool indefinitely.

## Why

This is PR 2 of the agent-friendliness audit follow-ups (audit findings F10 + M3). PR 1 (#46) closed the structured-error and tool-split gaps. This PR closes the bare-URL return shape from `get_map_url` and the indefinite-hang risk from the un-timed `httpx.AsyncClient`.

## Test plan

- [x] `uv run pytest` — 150 tests pass (up from 136)
- [x] Coverage 98.55% (95% gate)
- [x] `uv run ruff check` clean
- [x] `uv run ty check` clean
- [x] New `test_map_result.py` exercises: `MapResult`/`SkippedIP` model shape, structured return from the new tool, populated `skipped_ips` for partial inputs, 100-entry truncation cap, deprecated alias `str` parity, `httpx.TimeoutException` → `timeout`, `httpx.HTTPStatusError` 500/404/401/403/429 dispatch, `httpx.AsyncClient(timeout=...)` constructor argument
- [ ] Manual smoke test against a live IPInfo token (recommended before merge)

## Backwards compatibility

The new tool return type (`MapResult` instead of `str`) is a **breaking change for `ipinfo_generate_map_url`** — but that tool only shipped in 0.5.0 (this dev cycle), so no existing client depends on it yet. The deprecated `get_map_url` alias preserves the 0.4.x `str` contract by extracting `.url` from the new MapResult, so cached 0.4.x clients keep working.

## Follow-ups

- **PR 3:** Expanded `instructions` with negative scope and cache documentation; derived `is_residential_proxy: bool` field on `ResidentialProxyDetails`; consolidated `IPINFO_API_TOKEN` reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)