### PR TITLE
Add live-API smoke test suite (opt-in, local-only)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,4 +22,6 @@ Before tagging a release, run:
 
     IPINFO_API_TOKEN=<your-token> uv run pytest -m smoke --no-cov
 
-Without the token the tests skip cleanly. Each run makes ~6 live API calls. The smoke suite catches upstream contract changes that mocked unit tests cannot. A transient failure (5xx, timeout) should be re-run before being filed as a bug.
+Without the token the tests skip cleanly. Each run makes ~6 live API calls. The smoke suite catches upstream contract changes that mocked unit tests cannot.
+
+Transient upstream conditions auto-skip rather than fail: any envelope with `temporary: true` and a `code` in `{quota_exceeded, timeout, api_error}` (the last covers IPInfo 5xx). If a smoke test reports SKIPPED with a "transient envelope" reason, re-run it; only persistent failures should be filed as bugs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,3 +13,13 @@
 ## FastMCP Documentation
 
 Use the `mcp__fastmcp__search_fast_mcp` tool to search FastMCP documentation for API references, patterns, and examples when working on this codebase.
+
+## Smoke tests
+
+Live-API smoke tests in `tests/smoke/` exercise each production tool against the real IPInfo API. They are excluded from the default `pytest` run (via the `-m 'not smoke'` filter) and from the published wheel and sdist.
+
+Before tagging a release, run:
+
+    IPINFO_API_TOKEN=<your-token> uv run pytest -m smoke --no-cov
+
+Without the token the tests skip cleanly. Each run makes ~6 live API calls. The smoke suite catches upstream contract changes that mocked unit tests cannot. A transient failure (5xx, timeout) should be re-run before being filed as a bug.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ mcp-server-ipinfo = "mcp_server_ipinfo.server:mcp.run"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.sdist]
+exclude = ["tests/smoke", "tests/smoke/**"]
+
 [tool.ty.src]
 exclude = ["tests/"]
 
@@ -57,7 +60,10 @@ exclude = ["tests/"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
-addopts = "--cov=mcp_server_ipinfo --cov-report=term-missing"
+addopts = "--cov=mcp_server_ipinfo --cov-report=term-missing -m 'not smoke'"
+markers = [
+    "smoke: live-API smoke tests; require IPINFO_API_TOKEN; opt in with `pytest -m smoke --no-cov`",
+]
 
 [tool.coverage.run]
 source = ["src/mcp_server_ipinfo"]

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -1,0 +1,55 @@
+"""Test fixtures for live-API smoke tests.
+
+These tests run against the real IPInfo API and require ``IPINFO_API_TOKEN``.
+They are excluded from the default ``pytest`` invocation via the
+``-m 'not smoke'`` filter in ``pyproject.toml`` and are also auto-skipped
+here when the token is absent so an explicit ``pytest -m smoke`` doesn't
+fire spurious 401s.
+"""
+
+import os
+
+import pytest
+from fastmcp import Client
+
+from mcp_server_ipinfo.server import mcp
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip smoke tests when the live API token is absent.
+
+    Belt-and-suspenders with the addopts marker filter:
+    - Default ``pytest`` skips smoke via ``-m 'not smoke'``.
+    - Explicit ``pytest -m smoke`` without a token gets a clean skip
+      instead of upstream auth errors.
+    """
+    if os.environ.get("IPINFO_API_TOKEN"):
+        return
+    skip_no_token = pytest.mark.skip(
+        reason="IPINFO_API_TOKEN not set; smoke tests require a live token"
+    )
+    for item in items:
+        if "smoke" in item.keywords:
+            item.add_marker(skip_no_token)
+
+
+@pytest.fixture
+async def client():
+    """Yield a fresh in-process Client per test.
+
+    Each Client opens its own lifespan, which gives a fresh ``IPInfoCache``
+    so every test makes a real upstream call (no cross-test cache hits).
+    """
+    async with Client(mcp) as c:
+        yield c
+
+
+def sc(result):
+    """Read ``structured_content`` from a CallToolResult.
+
+    FastMCP's ``.data`` doesn't auto-rehydrate complex Pydantic types
+    (``Decimal``, ``IPvAnyAddress``, ``HttpUrl``, nested models) and returns
+    ``None`` when rehydration fails. Real MCP clients consume
+    ``structured_content`` directly; smoke tests do the same.
+    """
+    return result.structured_content

--- a/tests/smoke/test_live_tools.py
+++ b/tests/smoke/test_live_tools.py
@@ -16,16 +16,25 @@ from fastmcp.exceptions import ToolError
 pytestmark = pytest.mark.smoke
 
 # Envelope codes that indicate transient upstream conditions, not bugs in
-# this server. When the smoke run hits one of these, skip the test instead
-# of failing — the structured contract still held (we got a valid envelope),
-# but verifying the success path requires the upstream to be cooperative.
-_TRANSIENT_CODES = frozenset({"quota_exceeded", "timeout"})
+# this server. When the smoke run hits one of these AND the envelope is
+# marked temporary=True, skip the test instead of failing — the structured
+# contract still held (we got a valid envelope), but verifying the success
+# path requires the upstream to be cooperative. ``api_error`` is in the set
+# because the server's upstream classifier maps 5xx responses to
+# ``api_error`` with ``temporary=True``; a non-temporary ``api_error`` (4xx
+# the classifier doesn't otherwise recognize) is still a real failure.
+_TRANSIENT_CODES = frozenset({"quota_exceeded", "timeout", "api_error"})
 
 
 def _parse_envelope(err: ToolError) -> dict:
     """Extract the JSON-encoded envelope from a ToolError message."""
     msg = str(err)
     return json.loads(msg[msg.index("{") :])
+
+
+def _is_transient(env: dict) -> bool:
+    """Whether an envelope represents a transient upstream condition."""
+    return env.get("code") in _TRANSIENT_CODES and env.get("temporary") is True
 
 
 def _skip_if_transient(err: ToolError) -> None:
@@ -36,7 +45,7 @@ def _skip_if_transient(err: ToolError) -> None:
     accept "API was unhappy" as a non-failure outcome.
     """
     env = _parse_envelope(err)
-    if env.get("code") in _TRANSIENT_CODES and env.get("temporary") is True:
+    if _is_transient(env):
         pytest.skip(f"transient envelope from upstream: {env['code']!r} — re-run later")
     raise err
 
@@ -99,7 +108,7 @@ async def test_check_residential_proxy_envelope_path(client):
         )
     except ToolError as e:
         env = _parse_envelope(e)
-        if env.get("code") in _TRANSIENT_CODES:
+        if _is_transient(env):
             pytest.skip(f"transient envelope: {env['code']!r}")
         assert env["code"] in {"auth_invalid", "auth_insufficient_scope"}, (
             f"unexpected envelope code: {env['code']!r}"

--- a/tests/smoke/test_live_tools.py
+++ b/tests/smoke/test_live_tools.py
@@ -1,0 +1,164 @@
+"""Live-API smoke tests for the v0.5.0 tool surface.
+
+Run with::
+
+    IPINFO_API_TOKEN=<your-token> uv run pytest -m smoke --no-cov
+
+Without the token the tests skip cleanly. Each run makes ~6 live API calls
+(the structured-error envelope test makes zero — pure boundary rejection).
+"""
+
+import json
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+pytestmark = pytest.mark.smoke
+
+# Envelope codes that indicate transient upstream conditions, not bugs in
+# this server. When the smoke run hits one of these, skip the test instead
+# of failing — the structured contract still held (we got a valid envelope),
+# but verifying the success path requires the upstream to be cooperative.
+_TRANSIENT_CODES = frozenset({"quota_exceeded", "timeout"})
+
+
+def _parse_envelope(err: ToolError) -> dict:
+    """Extract the JSON-encoded envelope from a ToolError message."""
+    msg = str(err)
+    return json.loads(msg[msg.index("{") :])
+
+
+def _skip_if_transient(err: ToolError) -> None:
+    """If err is a transient upstream envelope, pytest.skip with the reason.
+
+    Re-raises any other ToolError (real bugs, schema breakage, auth issues).
+    Use inside ``except ToolError as e:`` blocks where the test wants to
+    accept "API was unhappy" as a non-failure outcome.
+    """
+    env = _parse_envelope(err)
+    if env.get("code") in _TRANSIENT_CODES and env.get("temporary") is True:
+        pytest.skip(f"transient envelope from upstream: {env['code']!r} — re-run later")
+    raise err
+
+
+async def test_lookup_my_ip(client):
+    try:
+        r = await client.call_tool("ipinfo_lookup_my_ip", arguments={})
+    except ToolError as e:
+        _skip_if_transient(e)
+    d = r.structured_content
+    assert d.get("ip"), "ip field missing"
+    assert d.get("country"), "country field missing"
+    assert d.get("ts_retrieved"), "ts_retrieved missing"
+    assert r.is_error is False
+
+
+async def test_lookup_ips_single(client):
+    try:
+        r = await client.call_tool("ipinfo_lookup_ips", arguments={"ips": ["8.8.8.8"]})
+    except ToolError as e:
+        _skip_if_transient(e)
+    results = r.structured_content["result"]
+    assert len(results) == 1
+    assert results[0]["ip"] == "8.8.8.8"
+    assert results[0]["country"] == "US"
+
+
+async def test_lookup_ips_summary_mode(client):
+    try:
+        r = await client.call_tool(
+            "ipinfo_lookup_ips",
+            arguments={"ips": ["8.8.8.8"], "detail": "summary"},
+        )
+    except ToolError as e:
+        _skip_if_transient(e)
+    d = r.structured_content["result"][0]
+    for heavy in (
+        "continent",
+        "country_flag",
+        "country_flag_url",
+        "country_currency",
+        "abuse",
+        "domains",
+    ):
+        assert d.get(heavy) is None, f"{heavy} should be nulled in summary mode"
+    assert d.get("city"), "city should survive summary mode"
+    assert d.get("country"), "country should survive summary mode"
+
+
+async def test_check_residential_proxy_envelope_path(client):
+    """Either succeeds (Enterprise + add-on) OR raises a structured envelope.
+
+    Both outcomes are passes — what we're verifying is the structured
+    contract. Bare 401s without an envelope are the failure mode.
+    """
+    try:
+        r = await client.call_tool(
+            "ipinfo_check_residential_proxy",
+            arguments={"ip": "142.250.80.46"},
+        )
+    except ToolError as e:
+        env = _parse_envelope(e)
+        if env.get("code") in _TRANSIENT_CODES:
+            pytest.skip(f"transient envelope: {env['code']!r}")
+        assert env["code"] in {"auth_invalid", "auth_insufficient_scope"}, (
+            f"unexpected envelope code: {env['code']!r}"
+        )
+        assert env["temporary"] is False
+    else:
+        d = r.structured_content
+        assert "is_residential_proxy" in d
+
+
+async def test_generate_map_url_returns_structured_result(client):
+    try:
+        r = await client.call_tool(
+            "ipinfo_generate_map_url",
+            arguments={"ips": ["8.8.8.8", "1.1.1.1", "208.67.222.222"]},
+        )
+    except ToolError as e:
+        _skip_if_transient(e)
+    d = r.structured_content
+    assert d["url"].startswith("https://ipinfo.io/"), f"unexpected url: {d['url']}"
+    assert d["mapped_ip_count"] == 3
+    assert d["skipped_count"] == 0
+    assert d["truncated"] is False
+
+
+async def test_generate_map_url_sentinel_and_dupe_accounting(client):
+    """Verifies fix from PR #47: mapped + skipped == input length."""
+    ips = ["8.8.8.8", "8.8.8.8", "", "null", "192.168.1.1", "1.1.1.1"]
+    try:
+        r = await client.call_tool("ipinfo_generate_map_url", arguments={"ips": ips})
+    except ToolError as e:
+        _skip_if_transient(e)
+    d = r.structured_content
+    assert d["mapped_ip_count"] + d["skipped_count"] == len(ips), (
+        f"accounting mismatch: {d['mapped_ip_count']} + {d['skipped_count']} != {len(ips)}"
+    )
+    skipped_reasons = {s["ip"]: s["reason"] for s in d["skipped_ips"]}
+    assert "duplicate" in skipped_reasons.get("8.8.8.8", "").lower()
+    assert "private" in skipped_reasons.get("192.168.1.1", "").lower()
+
+
+async def test_deprecated_get_map_url_alias_still_works(client):
+    """Forwarding alias preserves the bare-string return for 0.4.x parity."""
+    try:
+        r = await client.call_tool("get_map_url", arguments={"ips": ["8.8.8.8"]})
+    except ToolError as e:
+        _skip_if_transient(e)
+    # Bare-string return — FastMCP wraps non-object roots in {"result": "<url>"}.
+    url = r.structured_content["result"]
+    assert isinstance(url, str)
+    assert url.startswith("https://ipinfo.io/")
+
+
+async def test_structured_error_envelope_on_invalid_input(client):
+    """No live API call — pure boundary rejection. Verifies envelope shape."""
+    with pytest.raises(ToolError) as excinfo:
+        await client.call_tool("ipinfo_lookup_ips", arguments={"ips": ["not-an-ip"]})
+    env = _parse_envelope(excinfo.value)
+    assert env["code"] == "no_valid_ips"
+    assert env["temporary"] is False
+    assert env["field"] == "ips"
+    assert env["repair"]["hint"]


### PR DESCRIPTION
## Summary

Brings the v0.5.0 release ad-hoc smoke script (previously ephemeral at `/tmp/smoke_test_v0_5_0.py`) into the repo as a permanent, opt-in pre-release verification step. The suite caught a real pre-existing bug ([#52](https://github.com/briandconnelly/mcp-server-ipinfo/issues/52) — silent batch failure for Lite tokens) on its first run and is the right kind of test to keep.

## Layout

- **`tests/smoke/conftest.py`** — per-test fresh `fastmcp.Client(mcp)` (clean lifespan + cache, so each test makes a real upstream call); `pytest_collection_modifyitems` hook auto-skips when `IPINFO_API_TOKEN` is absent.
- **`tests/smoke/test_live_tools.py`** — 8 tests under `pytestmark = pytest.mark.smoke`. Covers all 4 production tools, the `detail="summary"` toggle, the deprecated `get_map_url` forwarding alias, the sentinel/dupe accounting fix from #47, and the structured-error envelope on invalid input. Transient upstream conditions (`quota_exceeded`, `timeout`) skip cleanly via a shared `_skip_if_transient()` helper rather than failing.

## Conservative API usage

- **~5–6 live calls per intentional invocation.** The structured-error envelope test makes zero — pure boundary rejection.
- **Default `pytest` excludes them** via `addopts = "... -m 'not smoke'"`. Opt in with `uv run pytest -m smoke --no-cov`.
- **Belt-and-suspenders:** even with `-m smoke`, the suite skips cleanly if `IPINFO_API_TOKEN` is unset — no spurious 401s.

## Distribution exclusions

- **Wheel:** already excludes `tests/` entirely (no change needed; verified).
- **Sdist:** new `[tool.hatch.build.targets.sdist] exclude = ["tests/smoke", "tests/smoke/**"]` keeps smoke out of the source tarball while preserving the existing mocked tests for downstream re-verification.

## CI

**Strictly local; no automation.** No `workflow_dispatch` job, no token-as-secret, no scheduled cron. The smoke suite is a manual pre-tag step the maintainer invokes.

## Documentation

`CLAUDE.md` gains a "Smoke tests" section with the canonical invocation:

```sh
IPINFO_API_TOKEN=<your-token> uv run pytest -m smoke --no-cov
```

…the token-skip behavior, ~6-call cost per run, and a note that transient failures should be re-run before being filed as bugs.

## Verification (all 7 plan steps run locally)

| Step | Result |
|---|---|
| V1 default `pytest` excludes smoke | ✓ 164/172 tests collected, 8 deselected |
| V1b `-m smoke` collects smoke only | ✓ 8/172 tests collected, 164 deselected |
| V2 existing 164-test suite passes unchanged | ✓ 164 passed; coverage 98.59% |
| V3 `-m smoke` without token = clean skip | ✓ 8 skipped, 0 errors |
| V4 live `-m smoke` with token | ✓ 5 passed, 3 skipped (map endpoint rate-limited from earlier sessions; transient handler engaged correctly) |
| V5 sdist excludes `tests/smoke` | ✓ no smoke files in sdist; regular tests still ship |
| V6 wheel excludes all tests | ✓ no `tests/` in wheel |
| V7 ruff + ty clean | ✓ both pass |

## Out of scope (deliberate)

- Subprocess/stdio transport test — defer; in-process Client covers tool surface, lifespan, cache, IPInfo client. Stdio frame is fastmcp-framework concern.
- VCR.py / cassette recording — defeats the point (we want real API contact).
- `pytest-rerunfailures` for flaky-network — documented "re-run on transient" is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)