### PR TITLE
fix: stop batch lookups silently dropping fresh IPs; harden agent contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+This cycle hardens the agent-facing contract from a joint Claude + Codex
+audit. The headline fix is a correctness bug (B0): multi-IP lookups silently
+returned nothing on a cold cache.
+
+### Fixed
+- **Batch lookups silently dropped every freshly-fetched IP.** The ipinfo SDK
+  returns fresh batch entries as raw `dict`s (only cache/bogon hits are
+  `Details` objects), but `ipinfo_batch_lookup` kept entries only
+  `if hasattr(details, "all")` — so `ipinfo_lookup_ips` with 2+ uncached IPs
+  returned `[]`. The parser now accepts both shapes. (Single-IP lookups were
+  unaffected; the unit mock returned `Details` objects, masking it — the mock
+  now mirrors the real raw-dict shape, and a live multi-IP smoke test guards
+  the integration path.)
+- `ToolErrorEnvelope.request_id` is now populated with a server-generated
+  correlation id (uuid4 hex) on every raised error; previously always `null`.
+
+### Added
+- Partial batch failures are surfaced: IPs that fail upstream are logged
+  per-IP (capped) and counted in the summary instead of vanishing; if *every*
+  attempted lookup fails, a temporary `api_error` is raised rather than
+  returning an empty list that masks a systemic failure.
+- `serverInfo.version` now reports the package version (e.g. `0.5.0`) via
+  `FastMCP(version=...)`; it previously leaked the FastMCP library version,
+  defeating client-side capability fingerprinting and version gating.
+- `website_url` on the server for discoverability.
+- Per-tool `meta.error_codes` lists the stable codes each tool can raise, so
+  agents see the branch set from tool introspection without parsing the
+  server instructions.
+- `meta.removed_in = "0.6.0"` on the deprecated aliases (was prose-only).
+- `idempotentHint: true` annotation on all read-only tools.
+- A `format: "ip"` JSON Schema hint on IP-string inputs (non-enforcing; soft
+  runtime validation still returns structured envelopes for bad input).
+- Coarse progress reporting (`ctx.report_progress`) on the batch lookup path.
+- Schema-level `minItems`/`maxItems` on the deprecated `get_ip_details` alias,
+  matching `ipinfo_lookup_ips`.
+
+### Changed
+- **Breaking:** `ipinfo_lookup_ips` now defaults to `detail="summary"` (was
+  `"full"`). Lean-by-default for token efficiency; pass `detail="full"` for
+  every field.
+- **Breaking:** `detail="summary"` now **omits** the heavy nested blocks
+  (`continent`, `country_flag`, `country_flag_url`, `country_currency`,
+  `abuse`, `domains`) entirely rather than nulling them. The previous
+  shape-parity guarantee is dropped; callers using `record.get("continent")`
+  are unaffected, callers using `record["continent"]` should switch to `.get`.
+  The tool's output schema is unchanged (those fields remain optional).
+
 ## [0.5.0] - 2026-05-10
 
 This release reshapes the tool surface for better agent ergonomics: structured

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To run the latest from `main`:
 ## Tools
 
 - **`ipinfo_lookup_my_ip()`** — Geolocate the calling client's own IP. Takes no arguments. On stdio transports the result reflects this server's outbound IP, not the end user's.
-- **`ipinfo_lookup_ips(ips, detail="full")`** — Geolocate one or more specified IPs. `detail="summary"` strips heavy nested blocks (continent, flags, currency, abuse, domains) for batch token savings while preserving shape parity. Capped at 500,000 IPs per call. Invalid or special-use addresses (private, loopback, etc.) are filtered with `ctx.warning()` and excluded from the result list — match returned `IPDetails.ip` values back to your input to detect what was dropped.
+- **`ipinfo_lookup_ips(ips, detail="summary")`** — Geolocate one or more specified IPs. Defaults to `detail="summary"`, which **omits** heavy nested blocks (continent, flags, currency, abuse, domains) for batch token savings; pass `detail="full"` for every field. Capped at 500,000 IPs per call. Invalid or special-use addresses (private, loopback, etc.) are filtered with `ctx.warning()` and excluded from the result list, as are IPs that fail upstream — match returned `IPDetails.ip` values back to your input to detect what was dropped. If every attempted lookup fails, a temporary `api_error` is raised.
 - **`ipinfo_check_residential_proxy(ip)`** — Check whether an IP is a known residential-proxy exit node. Tagged `enterprise` — requires the IPInfo residential-proxy add-on.
 - **`ipinfo_generate_map_url(ips)`** — Build an interactive ipinfo.io map for a set of IPs. Returns a `MapResult` with the URL, the count that made the map, the IPs filtered out (with reasons, capped at 100), and a `truncated` flag.
 
@@ -49,7 +49,7 @@ To run the latest from `main`:
 
 ### Errors
 
-Every tool raises a `ToolError` whose message is a JSON-encoded envelope with a stable `code` (`invalid_ip_address`, `special_ip_unsupported`, `no_valid_ips`, `too_many_ips`, `auth_invalid`, `auth_insufficient_scope`, `quota_exceeded`, `timeout`, `api_error`, `unknown_error`), a `temporary` flag, optional `retry_after_ms`, and a `repair` hint. Agents should parse the message as JSON and branch on `code`.
+Every tool raises a `ToolError` whose message is a JSON-encoded envelope with a stable `code` (`invalid_ip_address`, `special_ip_unsupported`, `no_valid_ips`, `too_many_ips`, `auth_invalid`, `auth_insufficient_scope`, `quota_exceeded`, `timeout`, `api_error`, `unknown_error`), a `temporary` flag, optional `retry_after_ms`, a `repair` hint, and a `request_id` correlation id. Agents should parse the message as JSON and branch on `code`. Each tool also advertises the subset of codes it can raise via `meta.error_codes`, so you can see the branch set from tool introspection.
 
 ### Deprecated tools
 

--- a/src/mcp_server_ipinfo/ipinfo.py
+++ b/src/mcp_server_ipinfo/ipinfo.py
@@ -93,7 +93,7 @@ async def ipinfo_batch_lookup(
     handler: ipinfo.AsyncHandler,
     ips: list[str],
     raise_on_fail: bool = False,
-) -> dict[str, IPDetails]:
+) -> tuple[dict[str, IPDetails], dict[str, str]]:
     """
     Retrieve detailed information about multiple IP addresses.
 
@@ -103,23 +103,54 @@ async def ipinfo_batch_lookup(
         raise_on_fail: If False, return partial results on errors.
 
     Returns:
-        Dictionary mapping IP addresses to their IPDetails.
+        A ``(results, failed)`` tuple. ``results`` maps each successfully
+        resolved IP to its ``IPDetails``; ``failed`` maps each IP that could
+        not be resolved (or whose payload could not be parsed) to a short
+        reason string. Every input IP appears in exactly one of the two maps,
+        so callers can detect partial failures instead of silently receiving a
+        shorter list than they asked for.
 
     Raises:
         ipinfo.exceptions.RequestQuotaExceededError: If raise_on_fail and quota exceeded
         ipinfo.exceptions.RequestFailedError: If raise_on_fail and request fails
     """
-    results = await handler.getBatchDetails(
+    raw_results = await handler.getBatchDetails(
         ip_addresses=ips,
         raise_on_fail=raise_on_fail,
     )
 
     ts = _utc_timestamp()
-    return {
-        ip: IPDetails(**_flatten_nested_response(details.all), ts_retrieved=ts)
-        for ip, details in results.items()
-        if hasattr(details, "all")  # Skip failed lookups
-    }
+    results: dict[str, IPDetails] = {}
+    failed: dict[str, str] = {}
+
+    for ip, entry in raw_results.items():
+        # The SDK returns ``Details`` objects for cache/bogon hits but raw
+        # ``dict``s for freshly fetched IPs (getBatchDetails does
+        # ``result.update(json_resp)`` with the parsed JSON). Accept both
+        # shapes; anything else is treated as a per-IP failure.
+        if hasattr(entry, "all"):
+            payload = entry.all
+        elif isinstance(entry, dict):
+            payload = entry
+        else:
+            failed[ip] = f"unrecognized batch entry ({type(entry).__name__})"
+            continue
+
+        try:
+            results[ip] = IPDetails(
+                **_flatten_nested_response(payload), ts_retrieved=ts
+            )
+        except Exception as exc:  # malformed or error payload for this IP
+            failed[ip] = f"unparseable batch entry: {type(exc).__name__}"
+
+    # IPs the upstream dropped entirely (e.g. a failed sub-batch under
+    # raise_on_fail=False) never appear in raw_results at all; record them so
+    # the caller gets a complete accounting of the request.
+    for ip in ips:
+        if ip not in results and ip not in failed:
+            failed[ip] = "no result returned by upstream"
+
+    return results, failed
 
 
 async def ipinfo_resproxy_lookup(

--- a/src/mcp_server_ipinfo/models.py
+++ b/src/mcp_server_ipinfo/models.py
@@ -53,8 +53,9 @@ class ToolErrorEnvelope(BaseModel):
     """Server-generated correlation ID (hex) for this error occurrence.
 
     Populated on every raised envelope so an agent can cite a stable identifier
-    when reporting a failure; the same ID is intended to appear in server logs
-    for the request. Not an upstream IPInfo request ID."""
+    when reporting a failure. It is generated at raise time and unique per
+    occurrence; the server does not currently emit it to its own logs, so do not
+    rely on it to grep server-side. Not an upstream IPInfo request ID."""
 
 
 class ASNDetails(BaseModel):

--- a/src/mcp_server_ipinfo/models.py
+++ b/src/mcp_server_ipinfo/models.py
@@ -50,7 +50,11 @@ class ToolErrorEnvelope(BaseModel):
     """Free-form repair guidance: hint text, alternative tool, allowed values."""
 
     request_id: str | None = None
-    """Correlation identifier for the originating request, if available."""
+    """Server-generated correlation ID (hex) for this error occurrence.
+
+    Populated on every raised envelope so an agent can cite a stable identifier
+    when reporting a failure; the same ID is intended to appear in server logs
+    for the request. Not an upstream IPInfo request ID."""
 
 
 class ASNDetails(BaseModel):

--- a/src/mcp_server_ipinfo/server.py
+++ b/src/mcp_server_ipinfo/server.py
@@ -158,9 +158,19 @@ IPString = Annotated[str, Field(json_schema_extra={"format": "ip"})]
 
 # Stable error codes each tool can raise, surfaced in tool ``meta`` so an agent
 # introspecting the tool list sees the branch set without parsing instructions.
-_INPUT_VALIDATION_ERROR_CODES = (
+# This advertises the *raiseable* set — codes the boundary demotes to data
+# (see below) are deliberately excluded so the contract stays accurate.
+#
+# Per-item input validation: in the list tools these never reach the caller as
+# errors. ``_filter_valid_ips`` catches them and routes the offending IP into
+# the ``skipped`` list instead, so only the single-IP tool raises them.
+_PER_ITEM_INPUT_ERROR_CODES = (
     "invalid_ip_address",
     "special_ip_unsupported",
+)
+# List-level input validation: raised by the list tools when the whole batch is
+# unusable (all inputs filtered) or oversized.
+_LIST_INPUT_ERROR_CODES = (
     "no_valid_ips",
     "too_many_ips",
 )
@@ -172,12 +182,13 @@ _UPSTREAM_ERROR_CODES = (
     "api_error",
     "unknown_error",
 )
-# List-input tools (lookup_ips, generate_map_url) can raise the full set.
-_LIST_TOOL_ERROR_CODES = list(_INPUT_VALIDATION_ERROR_CODES + _UPSTREAM_ERROR_CODES)
-# Single-IP tools validate one address but never hit the list-level codes.
+# List-input tools (lookup_ips, generate_map_url) demote per-item invalid/special
+# IPs to the skipped list rather than raising, so they advertise only the
+# list-level input codes plus the upstream set.
+_LIST_TOOL_ERROR_CODES = list(_LIST_INPUT_ERROR_CODES + _UPSTREAM_ERROR_CODES)
+# Single-IP tools validate one address, so the per-item codes DO reach the caller.
 _SINGLE_IP_TOOL_ERROR_CODES = [
-    "invalid_ip_address",
-    "special_ip_unsupported",
+    *_PER_ITEM_INPUT_ERROR_CODES,
     *_UPSTREAM_ERROR_CODES,
 ]
 # my_ip takes no input, so only upstream/auth codes apply.
@@ -846,6 +857,9 @@ async def ipinfo_generate_map_url(
         "deprecated_since": "0.5.0",
         "replaced_by": "ipinfo_lookup_ips",
         "removed_in": "0.6.0",
+        # Forwards to the my_ip and batch paths; the list set is the superset of
+        # both (my_ip raises only upstream codes), so it covers either branch.
+        "error_codes": _LIST_TOOL_ERROR_CODES,
     },
 )
 async def get_ip_details(
@@ -888,6 +902,7 @@ async def get_ip_details(
         "deprecated_since": "0.5.0",
         "replaced_by": "ipinfo_check_residential_proxy",
         "removed_in": "0.6.0",
+        "error_codes": _SINGLE_IP_TOOL_ERROR_CODES,
     },
 )
 async def get_residential_proxy_info(
@@ -919,6 +934,7 @@ async def get_residential_proxy_info(
         "deprecated_since": "0.5.0",
         "replaced_by": "ipinfo_generate_map_url",
         "removed_in": "0.6.0",
+        "error_codes": _LIST_TOOL_ERROR_CODES,
     },
 )
 async def get_map_url(

--- a/src/mcp_server_ipinfo/server.py
+++ b/src/mcp_server_ipinfo/server.py
@@ -1,7 +1,10 @@
 import ipaddress
 import json
+import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from typing import Annotated, Any, Literal, NoReturn
 
 import httpx
@@ -43,9 +46,21 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[dict]:
         await handler.deinit()
 
 
+# Resolve the installed package version so serverInfo.version reports this
+# server's release (e.g. "0.5.0"), not the FastMCP library version. Clients
+# fingerprint and version-gate on this; reporting the dependency version would
+# hide releases such as the 0.6.0 alias removal.
+try:
+    __version__ = _pkg_version("mcp-server-ipinfo")
+except PackageNotFoundError:  # pragma: no cover - editable tree without metadata
+    __version__ = "0.0.0+unknown"
+
+
 # Create an MCP server
 mcp = FastMCP(
     name="IP Address Geolocation and Internet Service Provider Lookup",
+    version=__version__,
+    website_url="https://github.com/briandconnelly/mcp-server-ipinfo",
     instructions="""
     Geolocate IPv4/IPv6 addresses via ipinfo.io: location, ISP, ASN, and
     (on paid plans) privacy/VPN/Tor/proxy flags, carrier, company, abuse
@@ -53,9 +68,13 @@ mcp = FastMCP(
 
     Tools:
     - ipinfo_lookup_my_ip(): the calling client's own IP (no args).
-    - ipinfo_lookup_ips(ips, detail="full"): batch lookup; detail="summary"
-      nulls heavy nested blocks (continent, country_flag*, country_currency,
-      abuse, domains) for token savings while preserving shape.
+    - ipinfo_lookup_ips(ips, detail="summary"): batch lookup. The default
+      "summary" OMITS heavy nested blocks (continent, country_flag*,
+      country_currency, abuse, domains) for token savings; pass detail="full"
+      for every field. Results return in input order after dedup and
+      invalid-IP filtering. IPs that fail upstream are dropped from the list
+      and logged (compare returned IPDetails.ip against your input to find
+      them); if every attempted lookup fails, a temporary api_error is raised.
     - ipinfo_check_residential_proxy(ip): Enterprise residential-proxy add-on
       required (tagged "enterprise").
     - ipinfo_generate_map_url(ips): returns a MapResult
@@ -130,6 +149,40 @@ _HEAVY_NESTED_FIELDS: tuple[str, ...] = (
 
 DetailLevel = Literal["summary", "full"]
 
+# String type for IP-address inputs. The ``format: "ip"`` hint surfaces in the
+# generated JSON Schema (on the array ``items`` for list params) so agents can
+# see the expected shape without a hard pattern. Validation stays soft and
+# runtime so malformed/special IPs return a friendly structured envelope rather
+# than a schema-level 422.
+IPString = Annotated[str, Field(json_schema_extra={"format": "ip"})]
+
+# Stable error codes each tool can raise, surfaced in tool ``meta`` so an agent
+# introspecting the tool list sees the branch set without parsing instructions.
+_INPUT_VALIDATION_ERROR_CODES = (
+    "invalid_ip_address",
+    "special_ip_unsupported",
+    "no_valid_ips",
+    "too_many_ips",
+)
+_UPSTREAM_ERROR_CODES = (
+    "auth_invalid",
+    "auth_insufficient_scope",
+    "quota_exceeded",
+    "timeout",
+    "api_error",
+    "unknown_error",
+)
+# List-input tools (lookup_ips, generate_map_url) can raise the full set.
+_LIST_TOOL_ERROR_CODES = list(_INPUT_VALIDATION_ERROR_CODES + _UPSTREAM_ERROR_CODES)
+# Single-IP tools validate one address but never hit the list-level codes.
+_SINGLE_IP_TOOL_ERROR_CODES = [
+    "invalid_ip_address",
+    "special_ip_unsupported",
+    *_UPSTREAM_ERROR_CODES,
+]
+# my_ip takes no input, so only upstream/auth codes apply.
+_MY_IP_TOOL_ERROR_CODES = list(_UPSTREAM_ERROR_CODES)
+
 MAX_LOOKUP_IPS = 500_000
 
 # Cap on the size of MapResult.skipped_ips so a 500K-IP submission with all
@@ -170,6 +223,7 @@ def _raise_envelope(
         value=value,
         retry_after_ms=retry_after_ms,
         repair=repair,
+        request_id=uuid.uuid4().hex,
     )
     raise ToolError(envelope.model_dump_json())
 
@@ -421,15 +475,18 @@ async def _filter_valid_ips(
     return valid, skipped
 
 
-def _summarize_for_batch(details: IPDetails) -> IPDetails:
-    """Drop heavy nested blocks from an IPDetails for batch token efficiency.
+def _project_summary(details: IPDetails) -> dict[str, Any]:
+    """Project an IPDetails to a token-lean dict for ``detail="summary"``.
 
-    Returns a copy with the deeply-nested decorative fields nulled out
-    (continent, country_flag, country_flag_url, country_currency, abuse,
-    domains). Shape parity with full detail is preserved so existing
-    parsers continue to work.
+    Omits the heavy nested blocks entirely (continent, country_flag,
+    country_flag_url, country_currency, abuse, domains) rather than nulling
+    them, so summary responses are genuinely smaller on the wire. Every omitted
+    field is Optional on IPDetails, so the projected dict stays valid against
+    the tool's auto-generated outputSchema (which is preserved by keeping the
+    ``-> list[IPDetails]`` return annotation). Callers needing these blocks
+    pass ``detail="full"``.
     """
-    return details.model_copy(update={field: None for field in _HEAVY_NESTED_FIELDS})
+    return details.model_dump(mode="json", exclude=set(_HEAVY_NESTED_FIELDS))
 
 
 async def _do_my_ip_lookup(
@@ -493,7 +550,12 @@ async def _do_batch_lookup(
     if cached_results:
         await ctx.info(f"Found {len(cached_results)} IPs in cache")
 
+    # Coarse progress for long batches: cache-resolved portion is done before
+    # any network call. No-op when the client supplied no progress token.
+    await ctx.report_progress(progress=len(cached_results), total=len(valid_ips))
+
     new_results: dict[str, IPDetails] = {}
+    failed: dict[str, str] = {}
     if ips_to_lookup:
         await ctx.info(f"Looking up {len(ips_to_lookup)} IP address(es)")
         try:
@@ -501,7 +563,7 @@ async def _do_batch_lookup(
                 result = await ipinfo_lookup(handler, ips_to_lookup[0])
                 new_results[ips_to_lookup[0]] = result
             else:
-                new_results = await ipinfo_batch_lookup(
+                new_results, failed = await ipinfo_batch_lookup(
                     handler, ips_to_lookup, raise_on_fail=False
                 )
             await cache.set_batch(new_results)
@@ -509,12 +571,43 @@ async def _do_batch_lookup(
             await ctx.error(f"IP lookup failed: {e}")
             _raise_from_upstream(e)
 
+    await ctx.report_progress(progress=len(valid_ips), total=len(valid_ips))
+
+    # Surface IPs that were valid and attempted but dropped by the upstream
+    # batch (partial failure). Without this an agent cannot distinguish "the
+    # API had no data / errored for this IP" from "this IP was never sent".
+    # Per-IP warnings are capped like the input-filter warnings.
+    if failed:
+        for ip, reason in list(failed.items())[:MAX_SKIP_WARNINGS]:
+            await ctx.warning(f"Lookup failed for {ip}: {reason}")
+        await ctx.error(
+            f"{len(failed)} of {len(ips_to_lookup)} attempted IP(s) failed "
+            "upstream and are absent from the result; compare returned "
+            "IPDetails.ip against your input to identify them."
+        )
+
     all_results = {**cached_results, **new_results}
     ordered_results = [all_results[ip] for ip in valid_ips if ip in all_results]
 
+    # If every attempted lookup failed (and nothing was cached), don't return
+    # an empty list that masks a systemic upstream failure — raise a temporary
+    # error so the agent retries instead of treating "" as "no data".
+    if not ordered_results and failed:
+        _raise_envelope(
+            "api_error",
+            f"All {len(failed)} attempted IP lookup(s) failed upstream.",
+            temporary=True,
+            field="ips",
+            repair={
+                "hint": "Retry; the upstream batch returned no usable results.",
+                "failed_count": len(failed),
+            },
+        )
+
     await ctx.info(
         f"Returning {len(ordered_results)} result(s) "
-        f"({len(skipped)} skipped, {len(cached_results)} cached)"
+        f"({len(skipped)} skipped, {len(cached_results)} cached, "
+        f"{len(failed)} failed upstream)"
     )
 
     return ordered_results
@@ -530,8 +623,12 @@ def _build_skipped_list(
 
 
 @mcp.tool(
-    annotations={"readOnlyHint": True, "openWorldHint": True},
-    meta={"introduced_in": "0.5.0"},
+    annotations={
+        "readOnlyHint": True,
+        "openWorldHint": True,
+        "idempotentHint": True,
+    },
+    meta={"introduced_in": "0.5.0", "error_codes": _MY_IP_TOOL_ERROR_CODES},
 )
 async def ipinfo_lookup_my_ip(
     ctx: Context = CurrentContext(),
@@ -547,12 +644,16 @@ async def ipinfo_lookup_my_ip(
 
 
 @mcp.tool(
-    annotations={"readOnlyHint": True, "openWorldHint": True},
-    meta={"introduced_in": "0.5.0"},
+    annotations={
+        "readOnlyHint": True,
+        "openWorldHint": True,
+        "idempotentHint": True,
+    },
+    meta={"introduced_in": "0.5.0", "error_codes": _LIST_TOOL_ERROR_CODES},
 )
 async def ipinfo_lookup_ips(
     ips: Annotated[
-        list[str],
+        list[IPString],
         Field(
             description="IPv4/IPv6 addresses to look up. Invalid or special-use IPs are filtered.",
             min_length=1,
@@ -564,33 +665,48 @@ async def ipinfo_lookup_ips(
         DetailLevel,
         Field(
             description=(
-                "'full' returns every IPDetails field; 'summary' nulls heavy "
-                "nested blocks (continent, country_flag*, country_currency, "
-                "abuse, domains) for batch token savings while preserving shape."
+                "'summary' (default) OMITS heavy nested blocks (continent, "
+                "country_flag*, country_currency, abuse, domains) for batch "
+                "token savings; 'full' returns every IPDetails field."
             ),
         ),
-    ] = "full",
+    ] = "summary",
     ctx: Context = CurrentContext(),
 ) -> list[IPDetails]:
     """Geolocate one or more IPs and return ISP/ASN details.
 
-    Returns a list of IPDetails in input order (after dedup and invalid-IP
-    filtering). Match results back to your input via the `ip` field. Capped
-    at 500,000 IPs per call (`too_many_ips` if exceeded). Higher plan tiers
-    populate more fields; see the server instructions for the
-    Lite/Core/Plus/Enterprise tier mapping. Errors raise ToolError with a
-    JSON-encoded envelope.
+    Returns a list in input order (after dedup and invalid-IP filtering); match
+    results back to your input via the `ip` field. IPs that fail upstream are
+    omitted and logged, and if every attempted lookup fails a temporary
+    `api_error` is raised. Defaults to `detail="summary"` (heavy nested blocks
+    omitted); pass `detail="full"` for every field. Capped at 500,000 IPs per
+    call (`too_many_ips` if exceeded). Higher plan tiers populate more fields;
+    see the server instructions for the Lite/Core/Plus/Enterprise tier mapping.
+    Errors raise ToolError with a JSON-encoded envelope.
     """
     handler, cache = _get_handler_and_cache(ctx)
     results = await _do_batch_lookup(handler, cache, ips, ctx)
     if detail == "summary":
-        return [_summarize_for_batch(r) for r in results]
+        # Project to token-lean dicts. The return annotation stays
+        # list[IPDetails] so the rich outputSchema is preserved; the omitted
+        # fields are all optional, so the projection is schema-valid. FastMCP
+        # serializes the raw return value, so returning dicts here is fine.
+        projected: list[Any] = [_project_summary(r) for r in results]
+        return projected
     return results
 
 
 @mcp.tool(
-    annotations={"readOnlyHint": True, "openWorldHint": True},
-    meta={"introduced_in": "0.5.0", "plan_required": "residential_proxy_addon"},
+    annotations={
+        "readOnlyHint": True,
+        "openWorldHint": True,
+        "idempotentHint": True,
+    },
+    meta={
+        "introduced_in": "0.5.0",
+        "plan_required": "residential_proxy_addon",
+        "error_codes": _SINGLE_IP_TOOL_ERROR_CODES,
+    },
     tags={"enterprise"},
 )
 async def ipinfo_check_residential_proxy(
@@ -599,6 +715,7 @@ async def ipinfo_check_residential_proxy(
         Field(
             description="IPv4/IPv6 address to classify.",
             examples=["142.250.80.46"],
+            json_schema_extra={"format": "ip"},
         ),
     ],
     ctx: Context = CurrentContext(),
@@ -628,13 +745,17 @@ async def ipinfo_check_residential_proxy(
 
 
 @mcp.tool(
-    annotations={"readOnlyHint": True, "openWorldHint": True},
-    meta={"introduced_in": "0.5.0"},
+    annotations={
+        "readOnlyHint": True,
+        "openWorldHint": True,
+        "idempotentHint": True,
+    },
+    meta={"introduced_in": "0.5.0", "error_codes": _LIST_TOOL_ERROR_CODES},
     timeout=MAP_TOOL_TIMEOUT_SECONDS,
 )
 async def ipinfo_generate_map_url(
     ips: Annotated[
-        list[str],
+        list[IPString],
         Field(
             description="IPv4/IPv6 addresses to plot. Invalid or special-use IPs are filtered.",
             min_length=1,
@@ -715,13 +836,21 @@ async def ipinfo_generate_map_url(
 
 
 @mcp.tool(
-    annotations={"readOnlyHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "openWorldHint": True,
+        "idempotentHint": True,
+    },
     tags={"deprecated"},
-    meta={"deprecated_since": "0.5.0", "replaced_by": "ipinfo_lookup_ips"},
+    meta={
+        "deprecated_since": "0.5.0",
+        "replaced_by": "ipinfo_lookup_ips",
+        "removed_in": "0.6.0",
+    },
 )
 async def get_ip_details(
     ips: Annotated[
-        list[str] | None,
+        list[IPString] | None,
         Field(
             description=(
                 "[DEPRECATED in 0.5.0; use ipinfo_lookup_my_ip when ips is None, "
@@ -730,6 +859,8 @@ async def get_ip_details(
                 "more IPs. If not provided, analyzes the requesting client's IP "
                 "address."
             ),
+            min_length=1,
+            max_length=MAX_LOOKUP_IPS,
             examples=[["8.8.8.8"], ["8.8.8.8", "1.1.1.1", "208.67.222.222"]],
         ),
     ] = None,
@@ -747,11 +878,16 @@ async def get_ip_details(
 
 
 @mcp.tool(
-    annotations={"readOnlyHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "openWorldHint": True,
+        "idempotentHint": True,
+    },
     tags={"deprecated"},
     meta={
         "deprecated_since": "0.5.0",
         "replaced_by": "ipinfo_check_residential_proxy",
+        "removed_in": "0.6.0",
     },
 )
 async def get_residential_proxy_info(
@@ -773,16 +909,21 @@ async def get_residential_proxy_info(
 
 
 @mcp.tool(
-    annotations={"readOnlyHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "openWorldHint": True,
+        "idempotentHint": True,
+    },
     tags={"deprecated"},
     meta={
         "deprecated_since": "0.5.0",
         "replaced_by": "ipinfo_generate_map_url",
+        "removed_in": "0.6.0",
     },
 )
 async def get_map_url(
     ips: Annotated[
-        list[str],
+        list[IPString],
         Field(
             description=(
                 "[DEPRECATED in 0.5.0; use ipinfo_generate_map_url. Removed in "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,10 @@ def mock_handler() -> AsyncMock:
         return create_mock_details(ip_address)
 
     async def mock_get_batch_details(ip_addresses, raise_on_fail=True):
-        return {ip: create_mock_details(ip) for ip in ip_addresses}
+        # Mirror the real SDK: freshly fetched IPs come back as raw dicts
+        # (getBatchDetails does result.update(json_resp)), not Details objects.
+        # Returning Details here would mask the hasattr(.all) silent-drop bug.
+        return {ip: create_mock_details(ip).all for ip in ip_addresses}
 
     async def mock_get_resproxy(ip_address):
         return create_mock_resproxy_details(ip_address)
@@ -115,6 +118,7 @@ def mock_context() -> MagicMock:
     ctx.debug = AsyncMock()
     ctx.warning = AsyncMock()
     ctx.error = AsyncMock()
+    ctx.report_progress = AsyncMock()
     return ctx
 
 

--- a/tests/smoke/test_live_tools.py
+++ b/tests/smoke/test_live_tools.py
@@ -4,7 +4,7 @@ Run with::
 
     IPINFO_API_TOKEN=<your-token> uv run pytest -m smoke --no-cov
 
-Without the token the tests skip cleanly. Each run makes ~6 live API calls
+Without the token the tests skip cleanly. Each run makes ~7 live API calls
 (the structured-error envelope test makes zero — pure boundary rejection).
 """
 
@@ -73,6 +73,25 @@ async def test_lookup_ips_single(client):
     assert results[0]["country"] == "US"
 
 
+async def test_lookup_ips_multiple_fresh(client):
+    """Fresh multi-IP lookup exercises the real batch path (getBatchDetails).
+
+    Regression guard for B0: the SDK returns fresh batch entries as raw dicts,
+    which a Details-only filter silently dropped — single-IP lookups (getDetails)
+    never caught it. Every requested public IP must come back.
+    """
+    ips = ["8.8.8.8", "1.1.1.1", "208.67.222.222"]
+    try:
+        r = await client.call_tool(
+            "ipinfo_lookup_ips", arguments={"ips": ips, "detail": "full"}
+        )
+    except ToolError as e:
+        _skip_if_transient(e)
+    results = r.structured_content["result"]
+    returned = {d["ip"] for d in results}
+    assert returned == set(ips), f"batch dropped IPs: missing {set(ips) - returned}"
+
+
 async def test_lookup_ips_summary_mode(client):
     try:
         r = await client.call_tool(
@@ -90,7 +109,7 @@ async def test_lookup_ips_summary_mode(client):
         "abuse",
         "domains",
     ):
-        assert d.get(heavy) is None, f"{heavy} should be nulled in summary mode"
+        assert heavy not in d, f"{heavy} should be omitted in summary mode"
     assert d.get("city"), "city should survive summary mode"
     assert d.get("country"), "country should survive summary mode"
 

--- a/tests/test_batch_failures.py
+++ b/tests/test_batch_failures.py
@@ -1,0 +1,153 @@
+"""Tests for batch-lookup failure surfacing and the structured error contract.
+
+The real ipinfo SDK returns freshly fetched batch entries as raw ``dict``s (it
+does ``result.update(json_resp)``), not ``Details`` objects. A ``Details``-only
+filter silently dropped every fresh result (bug B0); on top of that, IPs the
+upstream dropped were invisible to the caller (A11). These tests pin the
+raw-dict parsing, the partial-failure accounting, progress reporting, and the
+populated ``request_id`` on error envelopes.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from mcp_server_ipinfo.ipinfo import ipinfo_batch_lookup
+from mcp_server_ipinfo.models import IPDetails
+
+
+class TestBatchLookupParsing:
+    """ipinfo_batch_lookup accepts both SDK shapes and reports failures."""
+
+    async def test_parses_raw_dict_entries(self):
+        """Fresh batch entries arrive as raw dicts and must still parse (B0)."""
+        handler = MagicMock()
+        handler.getBatchDetails = AsyncMock(
+            return_value={
+                "8.8.8.8": {"ip": "8.8.8.8", "country": "US", "city": "Mountain View"},
+                "1.1.1.1": {"ip": "1.1.1.1", "country": "AU", "city": "Sydney"},
+            }
+        )
+        results, failed = await ipinfo_batch_lookup(handler, ["8.8.8.8", "1.1.1.1"])
+        assert set(results) == {"8.8.8.8", "1.1.1.1"}
+        assert all(isinstance(v, IPDetails) for v in results.values())
+        assert failed == {}
+
+    async def test_parses_details_objects_too(self):
+        """Cache/bogon entries arrive as Details objects (have .all)."""
+        handler = MagicMock()
+        det = MagicMock()
+        det.all = {"ip": "8.8.8.8", "country": "US"}
+        handler.getBatchDetails = AsyncMock(return_value={"8.8.8.8": det})
+        results, failed = await ipinfo_batch_lookup(handler, ["8.8.8.8"])
+        assert "8.8.8.8" in results
+        assert failed == {}
+
+    async def test_missing_ip_recorded_as_failed(self):
+        """An IP the upstream drops entirely lands in `failed`, not silently gone."""
+        handler = MagicMock()
+        handler.getBatchDetails = AsyncMock(
+            return_value={"8.8.8.8": {"ip": "8.8.8.8", "country": "US"}}
+        )
+        results, failed = await ipinfo_batch_lookup(handler, ["8.8.8.8", "9.9.9.9"])
+        assert "8.8.8.8" in results
+        assert "9.9.9.9" in failed
+        assert "no result" in failed["9.9.9.9"]
+
+    async def test_unparseable_entry_recorded_as_failed(self):
+        """A payload missing required fields is a per-IP failure, not a crash."""
+        handler = MagicMock()
+        handler.getBatchDetails = AsyncMock(
+            return_value={"8.8.8.8": {"error": "nope"}}  # no ip -> validation fails
+        )
+        results, failed = await ipinfo_batch_lookup(handler, ["8.8.8.8"])
+        assert results == {}
+        assert "8.8.8.8" in failed
+
+    async def test_every_input_is_accounted_for(self):
+        """results + failed together cover the whole input (no silent shrinkage)."""
+        handler = MagicMock()
+        handler.getBatchDetails = AsyncMock(
+            return_value={"1.2.3.4": {"ip": "1.2.3.4", "country": "US"}}
+        )
+        ips = ["1.2.3.4", "5.6.7.8", "9.10.11.12"]
+        results, failed = await ipinfo_batch_lookup(handler, ips)
+        assert set(results) | set(failed) == set(ips)
+
+
+class TestLookupIpsFailureSurfacing:
+    """ipinfo_lookup_ips logs dropped IPs and refuses to mask a total failure."""
+
+    async def test_partial_failure_warns_and_drops(self, mock_context_with_state):
+        from mcp_server_ipinfo.server import ipinfo_lookup_ips
+
+        handler = mock_context_with_state.lifespan_context["ipinfo_handler"]
+
+        async def partial(ip_addresses, raise_on_fail=True):
+            ip = ip_addresses[0]
+            return {ip: {"ip": ip, "country": "US", "city": "MV"}}
+
+        handler.getBatchDetails = partial
+
+        results = await ipinfo_lookup_ips(
+            ips=["8.8.8.8", "9.9.9.9"], detail="full", ctx=mock_context_with_state
+        )
+        assert {str(r.ip) for r in results} == {"8.8.8.8"}
+        warnings = " ".join(
+            c.args[0] for c in mock_context_with_state.warning.call_args_list
+        )
+        assert "9.9.9.9" in warnings
+
+    async def test_total_failure_raises_temporary(self, mock_context_with_state):
+        from mcp_server_ipinfo.server import ipinfo_lookup_ips
+
+        handler = mock_context_with_state.lifespan_context["ipinfo_handler"]
+
+        async def empty(ip_addresses, raise_on_fail=True):
+            return {}
+
+        handler.getBatchDetails = empty
+
+        with pytest.raises(ToolError) as exc:
+            await ipinfo_lookup_ips(
+                ips=["8.8.8.8", "9.9.9.9"], ctx=mock_context_with_state
+            )
+        env = json.loads(str(exc.value))
+        assert env["code"] == "api_error"
+        assert env["temporary"] is True
+        assert env["repair"]["failed_count"] == 2
+
+    async def test_progress_is_reported(self, mock_context_with_state):
+        """Long batches emit progress (no-op without a client progress token)."""
+        from mcp_server_ipinfo.server import ipinfo_lookup_ips
+
+        await ipinfo_lookup_ips(
+            ips=["8.8.8.8", "1.1.1.1"], detail="full", ctx=mock_context_with_state
+        )
+        assert mock_context_with_state.report_progress.await_count >= 1
+
+
+class TestErrorEnvelopeRequestId:
+    """Every raised envelope carries a populated correlation id (A5)."""
+
+    async def test_request_id_populated(self, mock_context_with_state):
+        from mcp_server_ipinfo.server import ipinfo_lookup_ips
+
+        with pytest.raises(ToolError) as exc:
+            await ipinfo_lookup_ips(ips=["192.168.1.1"], ctx=mock_context_with_state)
+        env = json.loads(str(exc.value))
+        assert env["code"] == "no_valid_ips"
+        assert env["request_id"]  # non-null, non-empty
+        assert len(env["request_id"]) == 32  # uuid4().hex
+
+    async def test_request_ids_are_unique(self, mock_context_with_state):
+        from mcp_server_ipinfo.server import ipinfo_lookup_ips
+
+        ids = set()
+        for _ in range(3):
+            with pytest.raises(ToolError) as exc:
+                await ipinfo_lookup_ips(ips=["not-an-ip"], ctx=mock_context_with_state)
+            ids.add(json.loads(str(exc.value))["request_id"])
+        assert len(ids) == 3

--- a/tests/test_split_tools.py
+++ b/tests/test_split_tools.py
@@ -2,7 +2,7 @@
 
 `get_ip_details` is split into:
 - `ipinfo_lookup_my_ip()` — no args; the calling client's IP.
-- `ipinfo_lookup_ips(ips, detail="full")` — list lookup with optional null-stripping.
+- `ipinfo_lookup_ips(ips, detail="summary")` — list lookup; summary omits heavy blocks.
 
 The original `get_ip_details` is retained as a deprecated alias.
 """
@@ -37,21 +37,34 @@ class TestIpinfoLookupMyIp:
 class TestIpinfoLookupIps:
     """ipinfo_lookup_ips returns a list and supports a `detail` toggle."""
 
-    async def test_full_detail_default(self, mock_context_with_state):
+    async def test_full_detail_returns_models(self, mock_context_with_state):
         from mcp_server_ipinfo.server import ipinfo_lookup_ips
 
-        results = await ipinfo_lookup_ips(ips=["8.8.8.8"], ctx=mock_context_with_state)
+        results = await ipinfo_lookup_ips(
+            ips=["8.8.8.8"], detail="full", ctx=mock_context_with_state
+        )
         assert len(results) == 1
         assert isinstance(results[0], IPDetails)
         assert results[0].city == "Mountain View"
 
-    async def test_summary_detail_drops_heavy_blocks(
+    async def test_summary_is_the_default(self, mock_context_with_state):
+        """detail defaults to "summary" (token-lean projected dicts)."""
+        from mcp_server_ipinfo.server import ipinfo_lookup_ips
+
+        results = await ipinfo_lookup_ips(ips=["8.8.8.8"], ctx=mock_context_with_state)
+        assert len(results) == 1
+        # Default summary yields projected dicts, not IPDetails models.
+        assert isinstance(results[0], dict)
+        assert results[0]["city"] == "Mountain View"
+        assert "continent" not in results[0]
+
+    async def test_summary_detail_omits_heavy_blocks(
         self, mock_context_with_state, sample_ip_details
     ):
-        """Summary mode nulls out the heavy nested blocks for token savings.
+        """Summary mode OMITS the heavy nested blocks entirely for token savings.
 
-        The agent opts in by passing detail="summary"; shape parity is
-        preserved (still IPDetails) so existing parsers don't break.
+        The blocks are absent from the projected dict (not merely nulled), while
+        full mode keeps the IPDetails model with every field present.
         """
         from mcp_server_ipinfo.server import ipinfo_lookup_ips
 
@@ -74,17 +87,22 @@ class TestIpinfoLookupIps:
             ips=["8.8.8.8"], detail="summary", ctx=mock_context_with_state
         )
 
-        # Full mode preserves the heavy blocks.
+        # Full mode (IPDetails model) preserves the heavy blocks.
         assert full[0].continent is not None
         assert full[0].country_flag is not None
-        # Summary mode nulls them out.
-        assert summary[0].continent is None
-        assert summary[0].country_flag is None
-        assert summary[0].country_flag_url is None
-        assert summary[0].country_currency is None
+        # Summary mode (projected dict) omits the heavy keys entirely.
+        for heavy in (
+            "continent",
+            "country_flag",
+            "country_flag_url",
+            "country_currency",
+            "abuse",
+            "domains",
+        ):
+            assert heavy not in summary[0], f"{heavy} should be omitted in summary"
         # Core geolocation fields survive.
-        assert summary[0].city == "Mountain View"
-        assert summary[0].country == "US"
+        assert summary[0]["city"] == "Mountain View"
+        assert summary[0]["country"] == "US"
 
 
 class TestRenamedTools:

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -102,7 +102,6 @@ class TestToolContract:
             (
                 "ipinfo_lookup_ips",
                 {
-                    "invalid_ip_address",
                     "no_valid_ips",
                     "too_many_ips",
                     "quota_exceeded",
@@ -126,6 +125,33 @@ class TestToolContract:
         codes = set(registered_tools["ipinfo_lookup_my_ip"].meta["error_codes"])
         assert "invalid_ip_address" not in codes
         assert "too_many_ips" not in codes
+
+    @pytest.mark.parametrize("name", ["ipinfo_lookup_ips", "ipinfo_generate_map_url"])
+    async def test_list_tools_omit_per_item_input_codes(self, registered_tools, name):
+        """List tools demote per-item invalid/special IPs to the skipped list
+        rather than raising, so those codes must not be advertised as raiseable."""
+        codes = set(registered_tools[name].meta["error_codes"])
+        assert "invalid_ip_address" not in codes
+        assert "special_ip_unsupported" not in codes
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("get_ip_details", {"no_valid_ips", "too_many_ips", "api_error"}),
+            (
+                "get_residential_proxy_info",
+                {"invalid_ip_address", "auth_insufficient_scope"},
+            ),
+            ("get_map_url", {"no_valid_ips", "timeout"}),
+        ],
+    )
+    async def test_deprecated_aliases_advertise_error_codes(
+        self, registered_tools, name, expected
+    ):
+        """Aliases forward to tools that raise structured errors, so their meta
+        must carry the same error_codes contract as the replacements."""
+        codes = set(registered_tools[name].meta.get("error_codes", []))
+        assert expected <= codes, f"{name} missing {expected - codes}"
 
     @pytest.mark.parametrize(
         "name",

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -31,7 +31,15 @@ class TestNewToolSchemas:
         detail_schema = tool.parameters["properties"]["detail"]
         # Literal["summary","full"] should expose an enum constraint.
         assert set(detail_schema.get("enum", [])) == {"summary", "full"}
-        assert detail_schema.get("default") == "full"
+        # Token-lean default: summary (heavy nested blocks omitted).
+        assert detail_schema.get("default") == "summary"
+
+    async def test_lookup_ips_items_carry_ip_format_hint(self, registered_tools):
+        tool = registered_tools["ipinfo_lookup_ips"]
+        items = tool.parameters["properties"]["ips"]["items"]
+        # Soft, non-enforcing schema hint so agents see the expected shape.
+        assert items.get("format") == "ip"
+        assert items.get("type") == "string"
 
     async def test_generate_map_url_caps_array_length(self, registered_tools):
         tool = registered_tools["ipinfo_generate_map_url"]
@@ -62,6 +70,78 @@ class TestDeprecationMetadata:
         assert tool.meta is not None
         assert tool.meta.get("deprecated_since") == "0.5.0"
         assert tool.meta.get("replaced_by") == replacement
+
+    @pytest.mark.parametrize(
+        "name",
+        ["get_ip_details", "get_residential_proxy_info", "get_map_url"],
+    )
+    async def test_alias_carries_removal_version(self, registered_tools, name):
+        """removed_in is structured meta, not just prose, so clients can gate on it."""
+        tool = registered_tools[name]
+        assert tool.meta.get("removed_in") == "0.6.0"
+
+    async def test_deprecated_list_alias_keeps_array_constraints(
+        self, registered_tools
+    ):
+        """get_ip_details forwards to the batch path, so it carries the same cap."""
+        tool = registered_tools["get_ip_details"]
+        ips_schema = tool.parameters["properties"]["ips"]
+        # Optional[list] nests the array constraints inside an anyOf branch.
+        array_branch = next(b for b in ips_schema["anyOf"] if b.get("type") == "array")
+        assert array_branch["minItems"] == 1
+        assert array_branch["maxItems"] == 500_000
+
+
+class TestToolContract:
+    """Agent-facing contract metadata: error codes, idempotency hints."""
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("ipinfo_lookup_my_ip", {"auth_invalid", "timeout", "api_error"}),
+            (
+                "ipinfo_lookup_ips",
+                {
+                    "invalid_ip_address",
+                    "no_valid_ips",
+                    "too_many_ips",
+                    "quota_exceeded",
+                },
+            ),
+            (
+                "ipinfo_check_residential_proxy",
+                {"invalid_ip_address", "auth_insufficient_scope"},
+            ),
+            ("ipinfo_generate_map_url", {"no_valid_ips", "timeout"}),
+        ],
+    )
+    async def test_tools_advertise_error_codes(self, registered_tools, name, expected):
+        """Each tool's meta.error_codes lets agents see the branch set up front."""
+        tool = registered_tools[name]
+        codes = set(tool.meta.get("error_codes", []))
+        assert expected <= codes, f"{name} missing {expected - codes}"
+
+    async def test_my_ip_omits_input_only_error_codes(self, registered_tools):
+        """my_ip takes no input, so input-validation codes must not appear."""
+        codes = set(registered_tools["ipinfo_lookup_my_ip"].meta["error_codes"])
+        assert "invalid_ip_address" not in codes
+        assert "too_many_ips" not in codes
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "ipinfo_lookup_my_ip",
+            "ipinfo_lookup_ips",
+            "ipinfo_check_residential_proxy",
+            "ipinfo_generate_map_url",
+        ],
+    )
+    async def test_readonly_tools_are_idempotent(self, registered_tools, name):
+        """Read-only lookups are safe to retry; advertise idempotentHint."""
+        ann = registered_tools[name].annotations
+        assert ann is not None
+        assert ann.idempotentHint is True
+        assert ann.readOnlyHint is True
 
 
 class TestNewToolMetadata:


### PR DESCRIPTION
## Summary

A joint Claude + Codex agent-friendliness audit of the 0.5.0 tool surface. The headline is a **Critical correctness bug (B0)** found while verifying audit findings against the SDK source; the rest hardens the agent-facing contract.

### B0 — batch lookups silently dropped every fresh IP
The ipinfo SDK returns freshly-fetched batch entries as raw `dict`s (only cache/bogon hits are `Details` objects), but `ipinfo_batch_lookup` kept entries only `if hasattr(details, "all")` — so `ipinfo_lookup_ips` with 2+ uncached IPs returned `[]` on a cold cache. The parser now accepts both shapes.

It was invisible to the test suite: the unit mock returned `Details`-shaped objects and no smoke test did a fresh ≥2-IP lookup. The mock now mirrors the real raw-dict shape, and a live `test_lookup_ips_multiple_fresh` guards the integration path.

### Also fixed
- Partial batch failures are surfaced (logged per-IP + counted); if *every* attempted lookup fails, a temporary `api_error` is raised instead of returning an empty list.
- `ToolErrorEnvelope.request_id` is now populated (server-generated uuid4 hex); previously always `null`.

### Agent-contract hardening
| Finding | Fix |
|---|---|
| serverInfo.version leaked the FastMCP lib version | report the package version via `FastMCP(version=...)` |
| error codes only in prose | per-tool `meta.error_codes` |
| no token-lean default | `ipinfo_lookup_ips` defaults to `detail="summary"` |
| blocking batch, no progress | coarse `ctx.report_progress` |
| no IP format discoverability | `format:"ip"` hint on IP inputs (non-enforcing) |
| read-only tools not marked idempotent | `idempotentHint: true` |
| alias removal version prose-only | `meta.removed_in = "0.6.0"` |
| summary nulled keys | summary **omits** heavy keys (schema preserved) |
| `get_ip_details` alias weaker schema | `minItems`/`maxItems` added |
| no `website_url` | added |

## Breaking changes
- `ipinfo_lookup_ips` now defaults to `detail="summary"` (was `"full"`).
- `detail="summary"` now **omits** the heavy nested blocks (`continent`, `country_flag`, `country_flag_url`, `country_currency`, `abuse`, `domains`) rather than nulling them. Output schema unchanged (fields stay optional); `record.get("continent")` callers unaffected, `record["continent"]` callers should switch to `.get`.

## Testing
- Unit: 189 passed, 98.31% coverage
- ruff check + ruff format + ty: clean (enforced via pre-commit)
- Live smoke: **9/9 passed, 0 skipped** against the real IPInfo API, including the new B0 regression guard

## Out of scope (follow-ups)
- `unknown_error` returns `str(exc)` — left as documented behavior (`mask_error_details=False`); could be redacted behind a flag.
- `latitude`/`longitude` `Decimal` constraints generate a JSON-Schema regex with look-ahead that Rust-regex clients can't compile (affects full mode too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)