### PR TITLE
fix: classify wholesale-empty batch lookups as auth_insufficient_scope (#52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,17 @@ returned nothing on a cold cache.
 
 ### Added
 - Partial batch failures are surfaced: IPs that fail upstream are logged
-  per-IP (capped) and counted in the summary instead of vanishing; if *every*
-  attempted lookup fails, a temporary `api_error` is raised rather than
-  returning an empty list that masks a systemic failure.
+  per-IP (capped) and counted in the summary instead of vanishing. If a
+  multi-IP batch resolves *no* IPs at all, the failure is raised rather than
+  masked behind an empty list, and the two total-failure modes are told apart:
+  a wholesale-empty `/batch` response (every IP missing from the response) now
+  raises a non-temporary `auth_insufficient_scope` instead of a "retry"
+  `api_error` — it is overwhelmingly a token-tier problem, since the SDK
+  swallows the `/batch` authorization failure for Lite-tier tokens (which must
+  use `/batch/lite`) and returns an empty map. The hint points the agent at
+  per-IP lookups or a Core+ upgrade instead of retrying a call that can never
+  succeed. A batch whose entries were returned but all failed to parse stays a
+  retryable `api_error`. (#52)
 - `serverInfo.version` now reports the package version (e.g. `0.5.0`) via
   `FastMCP(version=...)`; it previously leaked the FastMCP library version,
   defeating client-side capability fingerprinting and version gating.

--- a/src/mcp_server_ipinfo/ipinfo.py
+++ b/src/mcp_server_ipinfo/ipinfo.py
@@ -89,6 +89,14 @@ async def ipinfo_lookup(handler: ipinfo.AsyncHandler, ip: str | None) -> IPDetai
     )
 
 
+# Failure reason recorded when the upstream /batch response omitted an IP
+# entirely (as opposed to returning an entry that failed to parse). When every
+# attempted IP carries this reason, the upstream returned a wholesale-empty
+# map — the signature of a token whose tier lacks /batch access. Callers key
+# off this constant to tell that apart from per-IP parse failures.
+UPSTREAM_NO_RESULT_REASON = "no result returned by upstream"
+
+
 async def ipinfo_batch_lookup(
     handler: ipinfo.AsyncHandler,
     ips: list[str],
@@ -148,7 +156,7 @@ async def ipinfo_batch_lookup(
     # the caller gets a complete accounting of the request.
     for ip in ips:
         if ip not in results and ip not in failed:
-            failed[ip] = "no result returned by upstream"
+            failed[ip] = UPSTREAM_NO_RESULT_REASON
 
     return results, failed
 

--- a/src/mcp_server_ipinfo/server.py
+++ b/src/mcp_server_ipinfo/server.py
@@ -18,6 +18,7 @@ from pydantic import Field
 
 from .cache import IPInfoCache
 from .ipinfo import (
+    UPSTREAM_NO_RESULT_REASON,
     create_async_handler,
     ipinfo_batch_lookup,
     ipinfo_get_map_url,
@@ -74,7 +75,10 @@ mcp = FastMCP(
       for every field. Results return in input order after dedup and
       invalid-IP filtering. IPs that fail upstream are dropped from the list
       and logged (compare returned IPDetails.ip against your input to find
-      them); if every attempted lookup fails, a temporary api_error is raised.
+      them); if the batch resolves no IPs at all, the failure is raised rather
+      than masked — auth_insufficient_scope when the upstream returned nothing
+      (token tier likely lacks /batch access; look IPs up one at a time or
+      upgrade to Core+), otherwise a retryable api_error.
     - ipinfo_check_residential_proxy(ip): Enterprise residential-proxy add-on
       required (tagged "enterprise").
     - ipinfo_generate_map_url(ips): returns a MapResult
@@ -601,16 +605,52 @@ async def _do_batch_lookup(
     ordered_results = [all_results[ip] for ip in valid_ips if ip in all_results]
 
     # If every attempted lookup failed (and nothing was cached), don't return
-    # an empty list that masks a systemic upstream failure — raise a temporary
-    # error so the agent retries instead of treating "" as "no data".
+    # an empty list that masks the failure. This branch is only reachable from
+    # the multi-IP batch path: the single-IP path (above) raises a typed
+    # exception on failure, so it never lands here with a populated `failed`.
+    #
+    # Two total-failure modes are distinguished by the recorded reasons:
+    #   - Every IP carries UPSTREAM_NO_RESULT_REASON => the /batch response was
+    #     wholesale-empty. That is overwhelmingly a permanent tier/scope problem:
+    #     the ipinfo SDK swallows the /batch authorization failure for Lite-tier
+    #     tokens (which must use /batch/lite) and returns an empty map rather
+    #     than raising. Surface a non-temporary auth_insufficient_scope so the
+    #     agent switches to per-IP lookups instead of retrying a call that can
+    #     never succeed. (A genuinely transient total outage would also fail the
+    #     suggested per-IP fallback, so the agent still learns it is down.)
+    #   - Otherwise the upstream returned entries that failed to parse (malformed
+    #     payload or schema drift). Keep that a retryable api_error rather than
+    #     mislabeling it as a tier problem.
     if not ordered_results and failed:
+        upstream_returned_nothing = all(
+            reason == UPSTREAM_NO_RESULT_REASON for reason in failed.values()
+        )
+        if upstream_returned_nothing:
+            _raise_envelope(
+                "auth_insufficient_scope",
+                f"Batch lookup returned no results for any of the "
+                f"{len(ips_to_lookup)} attempted IP(s).",
+                temporary=False,
+                field="ips",
+                repair={
+                    "hint": (
+                        "The configured IPINFO_API_TOKEN may not have access to "
+                        "the /batch endpoint; Lite-tier tokens must use "
+                        "/batch/lite, which this server does not yet target. "
+                        "Look the IPs up one at a time (call ipinfo_lookup_ips "
+                        "with a single IP, or ipinfo_lookup_my_ip), or upgrade "
+                        "to a Core+ plan for multi-IP lookups."
+                    ),
+                    "attempted_count": len(ips_to_lookup),
+                },
+            )
         _raise_envelope(
             "api_error",
             f"All {len(failed)} attempted IP lookup(s) failed upstream.",
             temporary=True,
             field="ips",
             repair={
-                "hint": "Retry; the upstream batch returned no usable results.",
+                "hint": "Retry; the upstream returned no usable results.",
                 "failed_count": len(failed),
             },
         )
@@ -688,8 +728,11 @@ async def ipinfo_lookup_ips(
 
     Returns a list in input order (after dedup and invalid-IP filtering); match
     results back to your input via the `ip` field. IPs that fail upstream are
-    omitted and logged, and if every attempted lookup fails a temporary
-    `api_error` is raised. Defaults to `detail="summary"` (heavy nested blocks
+    omitted and logged; if the batch resolves no IPs at all the failure is
+    raised rather than masked — `auth_insufficient_scope` when the upstream
+    returned nothing (token tier likely lacks `/batch` access; look IPs up one
+    at a time or upgrade to Core+), otherwise a retryable `api_error`. Defaults
+    to `detail="summary"` (heavy nested blocks
     omitted); pass `detail="full"` for every field. Capped at 500,000 IPs per
     call (`too_many_ips` if exceeded). Higher plan tiers populate more fields;
     see the server instructions for the Lite/Core/Plus/Enterprise tier mapping.

--- a/tests/test_batch_failures.py
+++ b/tests/test_batch_failures.py
@@ -100,7 +100,15 @@ class TestLookupIpsFailureSurfacing:
         )
         assert "9.9.9.9" in warnings
 
-    async def test_total_failure_raises_temporary(self, mock_context_with_state):
+    async def test_wholesale_empty_batch_raises_insufficient_scope(
+        self, mock_context_with_state
+    ):
+        """A batch that returns nothing for every IP is a permanent tier/scope
+        problem (e.g. a Lite token, whose /batch access is denied and swallowed
+        by the SDK as an empty map), not a transient failure. It must raise a
+        non-temporary auth_insufficient_scope so the agent switches to per-IP
+        lookups instead of retrying a call that can never succeed.
+        """
         from mcp_server_ipinfo.server import ipinfo_lookup_ips
 
         handler = mock_context_with_state.lifespan_context["ipinfo_handler"]
@@ -109,6 +117,41 @@ class TestLookupIpsFailureSurfacing:
             return {}
 
         handler.getBatchDetails = empty
+
+        with pytest.raises(ToolError) as exc:
+            await ipinfo_lookup_ips(
+                ips=["8.8.8.8", "9.9.9.9"], ctx=mock_context_with_state
+            )
+        env = json.loads(str(exc.value))
+        assert env["code"] == "auth_insufficient_scope"
+        assert env["temporary"] is False
+        assert env["repair"]["attempted_count"] == 2
+        # The hint must point the agent at the per-IP workaround, not "retry".
+        hint = env["repair"]["hint"].lower()
+        assert "batch" in hint
+        assert "one at a time" in hint  # per-IP fallback
+        assert "core+" in hint  # upgrade path
+        assert "retry" not in hint
+
+    async def test_all_unparseable_batch_raises_temporary_api_error(
+        self, mock_context_with_state
+    ):
+        """A batch where the upstream returned entries but every one failed to
+        parse is NOT a tier/scope problem — it is a malformed/transient upstream
+        payload. It must stay a retryable api_error, not be misclassified as a
+        permanent auth_insufficient_scope (which is reserved for the
+        empty-result, /batch-access signature).
+        """
+        from mcp_server_ipinfo.server import ipinfo_lookup_ips
+
+        handler = mock_context_with_state.lifespan_context["ipinfo_handler"]
+
+        async def all_garbage(ip_addresses, raise_on_fail=True):
+            # Entries are present (so not an empty /batch response) but each
+            # lacks the required `ip` field, so IPDetails validation fails.
+            return {ip: {"error": "nope"} for ip in ip_addresses}
+
+        handler.getBatchDetails = all_garbage
 
         with pytest.raises(ToolError) as exc:
             await ipinfo_lookup_ips(


### PR DESCRIPTION
## Summary

Resolves the residual half of #52. A multi-IP `ipinfo_lookup_ips` call that resolved **zero** IPs was raised as a `temporary=True` `api_error` telling the agent to *retry*. For a Lite-tier token that is a **permanent** condition — the ipinfo SDK swallows the `/batch` authorization failure (Lite tokens must use `/batch/lite`) and returns an empty results map — so the agent retries a call that can never succeed and burns quota.

> Note: the *silent empty list* originally described in #52 was already fixed by #60 (the `(results, failed)` tuple + back-fill). This PR corrects the remaining mislabeling of that surfaced error.

## What changed

`_do_batch_lookup` now distinguishes the two total-failure modes by the recorded failure reasons:

- **Every IP missing from the response** (the new `UPSTREAM_NO_RESULT_REASON` back-fill reason) → non-temporary **`auth_insufficient_scope`**, with a hint pointing the agent at per-IP lookups or a Core+ upgrade.
- **Entries returned but all unparseable / mixed** → retryable **`api_error`**, preserving the prior contract for malformed or transient upstream payloads.

`auth_insufficient_scope` already exists in `_UPSTREAM_ERROR_CODES` and is advertised in every list tool's `meta.error_codes`, so the introspection contract is unchanged (no new error code). Agent-facing docstrings, server instructions, and the changelog are updated to describe both modes.

## Why `temporary=False` for the empty-batch case

A wholesale-empty `/batch` response is overwhelmingly the tier-mismatch signature. The asymmetry decides it: the permanent (Lite-tier) case is common and was the actual bug, while a rare transient total outage would *also* fail the per-IP fallback the hint suggests — so that case still surfaces correctly, but the common permanent case no longer loops.

## Testing

- New `test_wholesale_empty_batch_raises_insufficient_scope` — empty map → `auth_insufficient_scope`, `temporary=False`, hint asserts per-IP + Core+ guidance and absence of "retry".
- New `test_all_unparseable_batch_raises_temporary_api_error` — present-but-invalid entries → `api_error`, `temporary=True`.
- `uv run pytest -q` → **195 passed**, coverage 98.33% (gate 95%). `ruff check`, `ruff format --check`, `ty check` all clean.

Reviewed by Codex over two passes (initial review surfaced the over-broad branch; re-review confirmed all findings resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)