### PR TITLE
Add ipinfo_summarize_ips aggregation tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ returned nothing on a cold cache.
   correlation id (uuid4 hex) on every raised error; previously always `null`.
 
 ### Added
+- `ipinfo_summarize_ips(ips, group_by=("country", "asn"), top_n=50)` for
+  server-side aggregation of large IP batches into fixed-size counts and
+  percentages by country, continent, ASN, and privacy flags. The tool reuses
+  the batch lookup path, reports mapped/skipped/failed counts, caps each group
+  at `top_n`, and records true distinct group counts in `truncated_groups`
+  when capped. (#51)
 - Partial batch failures are surfaced: IPs that fail upstream are logged
   per-IP (capped) and counted in the summary instead of vanishing. If a
   multi-IP batch resolves *no* IPs at all, the failure is raised rather than

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ To run the latest from `main`:
 
 - **`ipinfo_lookup_my_ip()`** — Geolocate the calling client's own IP. Takes no arguments. On stdio transports the result reflects this server's outbound IP, not the end user's.
 - **`ipinfo_lookup_ips(ips, detail="summary")`** — Geolocate one or more specified IPs. Defaults to `detail="summary"`, which **omits** heavy nested blocks (continent, flags, currency, abuse, domains) for batch token savings; pass `detail="full"` for every field. Capped at 500,000 IPs per call. Invalid or special-use addresses (private, loopback, etc.) are filtered with `ctx.warning()` and excluded from the result list, as are IPs that fail upstream — match returned `IPDetails.ip` values back to your input to detect what was dropped. If every attempted lookup fails, a temporary `api_error` is raised.
+- **`ipinfo_summarize_ips(ips, group_by=("country", "asn"), top_n=50)`** — Geolocate and aggregate a batch into fixed-size counts and percentages by country, continent, ASN, and/or privacy flags. Use this for large log-analysis tasks where per-IP records would waste context. Returns mapped, skipped, and failed counts plus capped top-N groups.
 - **`ipinfo_check_residential_proxy(ip)`** — Check whether an IP is a known residential-proxy exit node. Tagged `enterprise` — requires the IPInfo residential-proxy add-on.
 - **`ipinfo_generate_map_url(ips)`** — Build an interactive ipinfo.io map for a set of IPs. Returns a `MapResult` with the URL, the count that made the map, the IPs filtered out (with reasons, capped at 100), and a `truncated` flag.
 

--- a/src/mcp_server_ipinfo/models.py
+++ b/src/mcp_server_ipinfo/models.py
@@ -406,3 +406,44 @@ class MapResult(BaseModel):
 
     truncated: bool
     """True when ``skipped_ips`` was capped at 100 because more were filtered."""
+
+
+class GroupCount(BaseModel):
+    """A counted summary bucket for a group in ``SummaryResult``."""
+
+    key: str
+    """Group key, such as ``US``, ``AS15169 Google LLC``, or ``vpn``."""
+
+    count: int
+    """Number of mapped IPs in this bucket."""
+
+    percent: float
+    """Percentage of mapped IPs in this bucket, from 0 to 100."""
+
+
+class SummaryResult(BaseModel):
+    """Fixed-size aggregate summary for a batch of IP lookups."""
+
+    mapped_ip_count: int
+    """IPs that successfully looked up and contributed to the aggregate."""
+
+    skipped_count: int
+    """Inputs filtered before lookup, including sentinels, duplicates, and special-use IPs."""
+
+    failed_count: int
+    """Valid IPs attempted upstream but omitted from the aggregate due to lookup failure."""
+
+    by_country: list[GroupCount] | None = None
+    """Top country-code buckets when requested."""
+
+    by_continent: list[GroupCount] | None = None
+    """Top continent-code buckets when requested and available from the plan."""
+
+    by_asn: list[GroupCount] | None = None
+    """Top ASN/organization buckets when requested."""
+
+    by_privacy: list[GroupCount] | None = None
+    """Privacy-flag buckets when requested and available from the plan."""
+
+    truncated_groups: dict[str, int] = Field(default_factory=dict)
+    """Group name to total distinct bucket count when output was capped."""

--- a/src/mcp_server_ipinfo/models.py
+++ b/src/mcp_server_ipinfo/models.py
@@ -437,13 +437,17 @@ class SummaryResult(BaseModel):
     """Top country-code buckets when requested."""
 
     by_continent: list[GroupCount] | None = None
-    """Top continent-code buckets when requested and available from the plan."""
+    """Top continent-code buckets when requested."""
 
     by_asn: list[GroupCount] | None = None
     """Top ASN/organization buckets when requested."""
 
     by_privacy: list[GroupCount] | None = None
-    """Privacy-flag buckets when requested and available from the plan."""
+    """Privacy-flag buckets when requested and available from the plan.
+
+    Privacy flags are independent, multi-label buckets: one IP can count
+    toward multiple flags, so privacy percentages may sum above 100.
+    """
 
     truncated_groups: dict[str, int] = Field(default_factory=dict)
     """Group name to total distinct bucket count when output was capped."""

--- a/src/mcp_server_ipinfo/server.py
+++ b/src/mcp_server_ipinfo/server.py
@@ -1,8 +1,10 @@
 import ipaddress
 import json
 import uuid
+from collections import Counter
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from typing import Annotated, Any, Literal, NoReturn
@@ -26,10 +28,12 @@ from .ipinfo import (
     ipinfo_resproxy_lookup,
 )
 from .models import (
+    GroupCount,
     IPDetails,
     MapResult,
     ResidentialProxyDetails,
     SkippedIP,
+    SummaryResult,
     ToolErrorCode,
     ToolErrorEnvelope,
 )
@@ -79,6 +83,9 @@ mcp = FastMCP(
       than masked — auth_insufficient_scope when the upstream returned nothing
       (token tier likely lacks /batch access; look IPs up one at a time or
       upgrade to Core+), otherwise a retryable api_error.
+    - ipinfo_summarize_ips(ips, group_by=["country", "asn"]): batch lookup
+      plus server-side aggregation into fixed-size counts/percentages, for
+      large log-analysis tasks where per-IP records would waste context.
     - ipinfo_check_residential_proxy(ip): Enterprise residential-proxy add-on
       required (tagged "enterprise").
     - ipinfo_generate_map_url(ips): returns a MapResult
@@ -152,6 +159,7 @@ _HEAVY_NESTED_FIELDS: tuple[str, ...] = (
 )
 
 DetailLevel = Literal["summary", "full"]
+SummaryGroup = Literal["country", "continent", "asn", "privacy"]
 
 # String type for IP-address inputs. The ``format: "ip"`` hint surfaces in the
 # generated JSON Schema (on the array ``items`` for list params) so agents can
@@ -199,6 +207,8 @@ _SINGLE_IP_TOOL_ERROR_CODES = [
 _MY_IP_TOOL_ERROR_CODES = list(_UPSTREAM_ERROR_CODES)
 
 MAX_LOOKUP_IPS = 500_000
+MAX_SUMMARY_GROUPS = 500
+DEFAULT_SUMMARY_TOP_N = 50
 
 # Cap on the size of MapResult.skipped_ips so a 500K-IP submission with all
 # entries filtered cannot inflate the response. truncated=True signals overflow.
@@ -213,6 +223,16 @@ MAX_SKIP_WARNINGS = 100
 # even if the underlying httpx client misbehaves; httpx itself enforces a
 # tighter per-request timeout (DEFAULT_MAP_TIMEOUT_SECONDS).
 MAP_TOOL_TIMEOUT_SECONDS = 60.0
+SUMMARY_TOOL_TIMEOUT_SECONDS = 120.0
+
+
+@dataclass(frozen=True)
+class _BatchLookupResult:
+    """Internal batch result with accounting needed by aggregate tools."""
+
+    records: list[IPDetails]
+    skipped: list[tuple[str, str]]
+    failed: dict[str, str]
 
 
 def _raise_envelope(
@@ -518,15 +538,15 @@ async def _do_my_ip_lookup(
         _raise_from_upstream(e)
 
 
-async def _do_batch_lookup(
+async def _do_batch_lookup_with_accounting(
     handler: ipinfo.AsyncHandler,
     cache: IPInfoCache,
     ips: list[str],
     ctx: Context,
-) -> list[IPDetails]:
+) -> _BatchLookupResult:
     """Validate, dedupe, cache-check, and look up a batch of IPs.
 
-    Shared between ipinfo_lookup_ips and the deprecated get_ip_details alias.
+    Shared by batch tools that need records plus skipped/failed accounting.
     """
     # Defense-in-depth: schema enforces the cap, but direct Python invocation
     # (or any caller bypassing FastMCP validation) can still pass an arbitrary
@@ -661,7 +681,20 @@ async def _do_batch_lookup(
         f"{len(failed)} failed upstream)"
     )
 
-    return ordered_results
+    return _BatchLookupResult(records=ordered_results, skipped=skipped, failed=failed)
+
+
+async def _do_batch_lookup(
+    handler: ipinfo.AsyncHandler,
+    cache: IPInfoCache,
+    ips: list[str],
+    ctx: Context,
+) -> list[IPDetails]:
+    """Validate, dedupe, cache-check, and look up a batch of IPs.
+
+    Shared between ipinfo_lookup_ips and the deprecated get_ip_details alias.
+    """
+    return (await _do_batch_lookup_with_accounting(handler, cache, ips, ctx)).records
 
 
 def _build_skipped_list(
@@ -671,6 +704,131 @@ def _build_skipped_list(
     truncated = len(skipped) > MAX_SKIPPED_IPS_REPORTED
     capped = skipped[:MAX_SKIPPED_IPS_REPORTED]
     return [SkippedIP(ip=ip, reason=reason) for ip, reason in capped], truncated
+
+
+def _asn_summary_key(details: IPDetails) -> str | None:
+    """Return a stable ASN bucket key from Core+ ASN fields or Lite org text."""
+    if details.asn is not None:
+        asn = details.asn.asn
+        name = details.asn.name
+        if asn and name:
+            return f"{asn} {name}"
+        return asn or name
+    return details.org
+
+
+def _continent_summary_key(details: IPDetails) -> str | None:
+    """Return the most compact continent bucket key available."""
+    if details.continent is None:
+        return None
+    return details.continent.code or details.continent.name
+
+
+def _count_groups(
+    keys: list[str],
+    *,
+    denominator: int,
+    top_n: int,
+    group_name: str,
+    truncated_groups: dict[str, int],
+) -> list[GroupCount]:
+    """Convert raw group keys into sorted, capped GroupCount records."""
+    counts = Counter(keys)
+    total_distinct = len(counts)
+    if total_distinct > top_n:
+        truncated_groups[group_name] = total_distinct
+
+    return [
+        GroupCount(
+            key=key,
+            count=count,
+            percent=round((count / denominator) * 100, 2) if denominator else 0.0,
+        )
+        for key, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))[
+            :top_n
+        ]
+    ]
+
+
+def _summarize_ip_details(
+    records: list[IPDetails],
+    *,
+    skipped_count: int,
+    failed_count: int,
+    group_by: list[SummaryGroup],
+    top_n: int,
+) -> SummaryResult:
+    """Aggregate IPDetails into fixed-size count and percentage summaries."""
+    mapped_count = len(records)
+    truncated_groups: dict[str, int] = {}
+
+    unique_groups = list(dict.fromkeys(group_by))
+    by_country = None
+    by_continent = None
+    by_asn = None
+    by_privacy = None
+
+    if "country" in unique_groups:
+        by_country = _count_groups(
+            [record.country for record in records if record.country],
+            denominator=mapped_count,
+            top_n=top_n,
+            group_name="country",
+            truncated_groups=truncated_groups,
+        )
+
+    if "continent" in unique_groups:
+        by_continent = _count_groups(
+            [
+                key
+                for key in (_continent_summary_key(record) for record in records)
+                if key is not None
+            ],
+            denominator=mapped_count,
+            top_n=top_n,
+            group_name="continent",
+            truncated_groups=truncated_groups,
+        )
+
+    if "asn" in unique_groups:
+        by_asn = _count_groups(
+            [
+                key
+                for key in (_asn_summary_key(record) for record in records)
+                if key is not None
+            ],
+            denominator=mapped_count,
+            top_n=top_n,
+            group_name="asn",
+            truncated_groups=truncated_groups,
+        )
+
+    if "privacy" in unique_groups:
+        privacy_keys: list[str] = []
+        for record in records:
+            if record.privacy is None:
+                continue
+            for key in ("vpn", "proxy", "tor", "relay", "hosting"):
+                if getattr(record.privacy, key):
+                    privacy_keys.append(key)
+        by_privacy = _count_groups(
+            privacy_keys,
+            denominator=mapped_count,
+            top_n=top_n,
+            group_name="privacy",
+            truncated_groups=truncated_groups,
+        )
+
+    return SummaryResult(
+        mapped_ip_count=mapped_count,
+        skipped_count=skipped_count,
+        failed_count=failed_count,
+        by_country=by_country,
+        by_continent=by_continent,
+        by_asn=by_asn,
+        by_privacy=by_privacy,
+        truncated_groups=truncated_groups,
+    )
 
 
 @mcp.tool(
@@ -748,6 +906,70 @@ async def ipinfo_lookup_ips(
         projected: list[Any] = [_project_summary(r) for r in results]
         return projected
     return results
+
+
+@mcp.tool(
+    annotations={
+        "readOnlyHint": True,
+        "openWorldHint": True,
+        "idempotentHint": True,
+    },
+    meta={"introduced_in": "0.6.0", "error_codes": _LIST_TOOL_ERROR_CODES},
+    timeout=SUMMARY_TOOL_TIMEOUT_SECONDS,
+)
+async def ipinfo_summarize_ips(
+    ips: Annotated[
+        list[IPString],
+        Field(
+            description="IPv4/IPv6 addresses to aggregate. Invalid or special-use IPs are filtered.",
+            min_length=1,
+            max_length=MAX_LOOKUP_IPS,
+            examples=[["8.8.8.8", "1.1.1.1", "208.67.222.222"]],
+        ),
+    ],
+    group_by: Annotated[
+        tuple[SummaryGroup, ...],
+        Field(
+            description=(
+                "Summary dimensions to include. Empty returns only mapped, "
+                "skipped, and failed counts."
+            ),
+            max_length=4,
+            examples=[["country", "asn"], ["privacy"], []],
+        ),
+    ] = ("country", "asn"),
+    top_n: Annotated[
+        int,
+        Field(
+            description=(
+                "Maximum buckets to return per requested group. "
+                "truncated_groups reports the true distinct count when capped."
+            ),
+            ge=1,
+            le=MAX_SUMMARY_GROUPS,
+        ),
+    ] = DEFAULT_SUMMARY_TOP_N,
+    ctx: Context = CurrentContext(),
+) -> SummaryResult:
+    """Aggregate one or more IP lookups into counts and percentages.
+
+    Uses the same validation, deduplication, cache, and upstream batch lookup
+    path as `ipinfo_lookup_ips`, but returns fixed-size summary buckets instead
+    of per-IP records. This is the preferred tool for large log-analysis tasks
+    such as "where did visitors come from?" when the caller does not need the
+    underlying records. Percentages are based on `mapped_ip_count`; filtered
+    and failed IPs are counted separately. Errors raise ToolError with a
+    JSON-encoded envelope.
+    """
+    handler, cache = _get_handler_and_cache(ctx)
+    batch = await _do_batch_lookup_with_accounting(handler, cache, ips, ctx)
+    return _summarize_ip_details(
+        batch.records,
+        skipped_count=len(batch.skipped),
+        failed_count=len(batch.failed),
+        group_by=list(group_by),
+        top_n=top_n,
+    )
 
 
 @mcp.tool(

--- a/tests/smoke/test_live_tools.py
+++ b/tests/smoke/test_live_tools.py
@@ -1,10 +1,10 @@
-"""Live-API smoke tests for the v0.5.0 tool surface.
+"""Live-API smoke tests for the production tool surface.
 
 Run with::
 
     IPINFO_API_TOKEN=<your-token> uv run pytest -m smoke --no-cov
 
-Without the token the tests skip cleanly. Each run makes ~7 live API calls
+Without the token the tests skip cleanly. Each run makes ~8 live API calls
 (the structured-error envelope test makes zero — pure boundary rejection).
 """
 
@@ -112,6 +112,24 @@ async def test_lookup_ips_summary_mode(client):
         assert heavy not in d, f"{heavy} should be omitted in summary mode"
     assert d.get("city"), "city should survive summary mode"
     assert d.get("country"), "country should survive summary mode"
+
+
+async def test_summarize_ips_returns_aggregate(client):
+    ips = ["8.8.8.8", "1.1.1.1", "208.67.222.222"]
+    try:
+        r = await client.call_tool(
+            "ipinfo_summarize_ips",
+            arguments={"ips": ips, "group_by": ["country", "asn"], "top_n": 50},
+        )
+    except ToolError as e:
+        _skip_if_transient(e)
+    d = r.structured_content
+    assert d["mapped_ip_count"] == 3
+    assert d["skipped_count"] == 0
+    assert d["failed_count"] == 0
+    assert d["by_country"], "country summary missing"
+    assert d["by_asn"], "ASN summary missing"
+    assert d["truncated_groups"] == {}
 
 
 async def test_check_residential_proxy_envelope_path(client):

--- a/tests/test_summarize_ips.py
+++ b/tests/test_summarize_ips.py
@@ -1,0 +1,142 @@
+"""Tests for server-side IP batch summaries."""
+
+from unittest.mock import AsyncMock
+
+from mcp_server_ipinfo.models import IPDetails, SummaryResult
+from mcp_server_ipinfo.server import ipinfo_summarize_ips
+
+
+def _details(ip: str, **kwargs) -> IPDetails:
+    return IPDetails(ip=ip, **kwargs)
+
+
+class TestIpinfoSummarizeIps:
+    async def test_groups_by_country_with_counts_and_percentages(
+        self, mock_context_with_state
+    ):
+        cache = mock_context_with_state.lifespan_context["cache"]
+        await cache.set("8.8.8.8", _details("8.8.8.8", country="US"))
+        await cache.set("9.9.9.9", _details("9.9.9.9", country="US"))
+        await cache.set("1.1.1.1", _details("1.1.1.1", country="AU"))
+
+        result = await ipinfo_summarize_ips(
+            ips=["8.8.8.8", "9.9.9.9", "1.1.1.1"],
+            group_by=("country",),
+            ctx=mock_context_with_state,
+        )
+
+        assert isinstance(result, SummaryResult)
+        assert result.mapped_ip_count == 3
+        assert result.skipped_count == 0
+        assert result.failed_count == 0
+        assert result.by_country is not None
+        assert [(item.key, item.count, item.percent) for item in result.by_country] == [
+            ("US", 2, 66.67),
+            ("AU", 1, 33.33),
+        ]
+        assert result.by_asn is None
+
+    async def test_empty_group_by_returns_counts_only(self, mock_context_with_state):
+        result = await ipinfo_summarize_ips(
+            ips=["8.8.8.8"],
+            group_by=(),
+            ctx=mock_context_with_state,
+        )
+
+        assert result.mapped_ip_count == 1
+        assert result.by_country is None
+        assert result.by_continent is None
+        assert result.by_asn is None
+        assert result.by_privacy is None
+
+    async def test_truncates_long_tail_groups(self, mock_context_with_state):
+        cache = mock_context_with_state.lifespan_context["cache"]
+        ips = [f"11.0.0.{i}" for i in range(1, 61)]
+        for i, ip in enumerate(ips, start=1):
+            await cache.set(ip, _details(ip, asn={"asn": f"AS{i}", "name": f"Org {i}"}))
+
+        result = await ipinfo_summarize_ips(
+            ips=ips,
+            group_by=("asn",),
+            top_n=50,
+            ctx=mock_context_with_state,
+        )
+
+        assert result.by_asn is not None
+        assert len(result.by_asn) == 50
+        assert result.truncated_groups == {"asn": 60}
+
+    async def test_privacy_aggregation_counts_true_flags(self, mock_context_with_state):
+        cache = mock_context_with_state.lifespan_context["cache"]
+        await cache.set(
+            "8.8.8.8",
+            _details("8.8.8.8", privacy={"vpn": True, "hosting": True}),
+        )
+        await cache.set(
+            "9.9.9.9",
+            _details("9.9.9.9", privacy={"vpn": True, "tor": True}),
+        )
+        await cache.set("1.1.1.1", _details("1.1.1.1"))
+
+        result = await ipinfo_summarize_ips(
+            ips=["8.8.8.8", "9.9.9.9", "1.1.1.1"],
+            group_by=("privacy",),
+            ctx=mock_context_with_state,
+        )
+
+        assert result.by_privacy is not None
+        assert [(item.key, item.count) for item in result.by_privacy] == [
+            ("vpn", 2),
+            ("hosting", 1),
+            ("tor", 1),
+        ]
+
+    async def test_lite_tier_without_privacy_returns_empty_privacy_group(
+        self, mock_context_with_state
+    ):
+        result = await ipinfo_summarize_ips(
+            ips=["8.8.8.8"],
+            group_by=("privacy",),
+            ctx=mock_context_with_state,
+        )
+
+        assert result.mapped_ip_count == 1
+        assert result.by_privacy == []
+
+    async def test_cache_records_contribute_to_summary(self, mock_context_with_state):
+        cache = mock_context_with_state.lifespan_context["cache"]
+        await cache.set("8.8.8.8", _details("8.8.8.8", country="US"))
+
+        result = await ipinfo_summarize_ips(
+            ips=["8.8.8.8", "1.1.1.1"],
+            group_by=("country",),
+            ctx=mock_context_with_state,
+        )
+
+        assert result.mapped_ip_count == 2
+        assert result.by_country is not None
+        assert [(item.key, item.count) for item in result.by_country] == [("US", 2)]
+
+    async def test_reports_skipped_and_failed_counts(self, mock_context_with_state):
+        handler = mock_context_with_state.lifespan_context["ipinfo_handler"]
+        handler.getBatchDetails = AsyncMock(
+            return_value={
+                "8.8.8.8": {
+                    "ip": "8.8.8.8",
+                    "country": "US",
+                    "org": "AS15169 Google LLC",
+                }
+            }
+        )
+
+        result = await ipinfo_summarize_ips(
+            ips=["8.8.8.8", "1.1.1.1", "192.168.1.1", "8.8.8.8"],
+            group_by=("country",),
+            ctx=mock_context_with_state,
+        )
+
+        assert result.mapped_ip_count == 1
+        assert result.skipped_count == 2
+        assert result.failed_count == 1
+        assert result.by_country is not None
+        assert [(item.key, item.count) for item in result.by_country] == [("US", 1)]

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -47,6 +47,31 @@ class TestNewToolSchemas:
         assert ips_schema["minItems"] == 1
         assert ips_schema["maxItems"] == 500_000
 
+    async def test_summarize_ips_caps_array_length(self, registered_tools):
+        tool = registered_tools["ipinfo_summarize_ips"]
+        ips_schema = tool.parameters["properties"]["ips"]
+        assert ips_schema["minItems"] == 1
+        assert ips_schema["maxItems"] == 500_000
+
+    async def test_summarize_ips_group_by_is_enum_array(self, registered_tools):
+        tool = registered_tools["ipinfo_summarize_ips"]
+        group_schema = tool.parameters["properties"]["group_by"]
+        assert group_schema["maxItems"] == 4
+        assert set(group_schema["items"].get("enum", [])) == {
+            "country",
+            "continent",
+            "asn",
+            "privacy",
+        }
+        assert group_schema.get("default") == ["country", "asn"]
+
+    async def test_summarize_ips_top_n_has_bounds(self, registered_tools):
+        tool = registered_tools["ipinfo_summarize_ips"]
+        top_n_schema = tool.parameters["properties"]["top_n"]
+        assert top_n_schema["minimum"] == 1
+        assert top_n_schema["maximum"] == 500
+        assert top_n_schema["default"] == 50
+
     async def test_my_ip_takes_no_args(self, registered_tools):
         tool = registered_tools["ipinfo_lookup_my_ip"]
         # Only the implicit Context parameter remains; no required args.
@@ -108,6 +133,14 @@ class TestToolContract:
                 },
             ),
             (
+                "ipinfo_summarize_ips",
+                {
+                    "no_valid_ips",
+                    "too_many_ips",
+                    "quota_exceeded",
+                },
+            ),
+            (
                 "ipinfo_check_residential_proxy",
                 {"invalid_ip_address", "auth_insufficient_scope"},
             ),
@@ -126,7 +159,10 @@ class TestToolContract:
         assert "invalid_ip_address" not in codes
         assert "too_many_ips" not in codes
 
-    @pytest.mark.parametrize("name", ["ipinfo_lookup_ips", "ipinfo_generate_map_url"])
+    @pytest.mark.parametrize(
+        "name",
+        ["ipinfo_lookup_ips", "ipinfo_summarize_ips", "ipinfo_generate_map_url"],
+    )
     async def test_list_tools_omit_per_item_input_codes(self, registered_tools, name):
         """List tools demote per-item invalid/special IPs to the skipped list
         rather than raising, so those codes must not be advertised as raiseable."""
@@ -158,6 +194,7 @@ class TestToolContract:
         [
             "ipinfo_lookup_my_ip",
             "ipinfo_lookup_ips",
+            "ipinfo_summarize_ips",
             "ipinfo_check_residential_proxy",
             "ipinfo_generate_map_url",
         ],
@@ -178,6 +215,7 @@ class TestNewToolMetadata:
         [
             "ipinfo_lookup_my_ip",
             "ipinfo_lookup_ips",
+            "ipinfo_summarize_ips",
             "ipinfo_check_residential_proxy",
             "ipinfo_generate_map_url",
         ],
@@ -185,7 +223,8 @@ class TestNewToolMetadata:
     async def test_introduced_in_meta(self, registered_tools, name):
         tool = registered_tools[name]
         assert tool.meta is not None
-        assert tool.meta.get("introduced_in") == "0.5.0"
+        expected = "0.6.0" if name == "ipinfo_summarize_ips" else "0.5.0"
+        assert tool.meta.get("introduced_in") == expected
 
     async def test_residential_proxy_marked_enterprise(self, registered_tools):
         tool = registered_tools["ipinfo_check_residential_proxy"]


### PR DESCRIPTION
## Summary
- add SummaryResult/GroupCount models and a new ipinfo_summarize_ips tool for fixed-size batch aggregation
- reuse the existing batch lookup path while preserving skipped and failed counts for the summary response
- document the tool and cover schema/aggregation behavior with tests

Closes #51

## Tests
- uv run --extra dev pytest
- prek run --all-files