### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-05-31
+
 This cycle hardens the agent-facing contract from a joint Claude + Codex
-audit. The headline fix is a correctness bug (B0): multi-IP lookups silently
+audit and completes the 0.5.0 deprecation cycle by removing the legacy tool
+aliases. The headline fix is a correctness bug (B0): multi-IP lookups silently
 returned nothing on a cold cache.
 
 ### Fixed
@@ -67,6 +70,14 @@ returned nothing on a cold cache.
   shape-parity guarantee is dropped; callers using `record.get("continent")`
   are unaffected, callers using `record["continent"]` should switch to `.get`.
   The tool's output schema is unchanged (those fields remain optional).
+
+### Removed
+- **Breaking:** the deprecated forwarding aliases `get_ip_details`,
+  `get_residential_proxy_info`, and `get_map_url` (deprecated in 0.5.0) are
+  removed as scheduled. Call `ipinfo_lookup_my_ip` / `ipinfo_lookup_ips`,
+  `ipinfo_check_residential_proxy`, and `ipinfo_generate_map_url` respectively.
+  Note that `get_map_url` returned a bare URL string; `ipinfo_generate_map_url`
+  returns a structured `MapResult`.
 
 ## [0.5.0] - 2026-05-10
 
@@ -226,7 +237,8 @@ The previous tool names remain as forwarding aliases scheduled for removal in
 - Response caching with 1-hour TTL
 - Pydantic models for API responses
 
-[Unreleased]: https://github.com/briandconnelly/mcp-server-ipinfo/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/briandconnelly/mcp-server-ipinfo/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/briandconnelly/mcp-server-ipinfo/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/briandconnelly/mcp-server-ipinfo/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/briandconnelly/mcp-server-ipinfo/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/briandconnelly/mcp-server-ipinfo/compare/v0.2.0...v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,20 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This cycle hardens the agent-facing contract from a joint Claude + Codex
 audit and completes the 0.5.0 deprecation cycle by removing the legacy tool
-aliases. The headline fix is a correctness bug (B0): multi-IP lookups silently
+aliases. The headline fix is a correctness bug: multi-IP lookups silently
 returned nothing on a cold cache.
-
-### Fixed
-- **Batch lookups silently dropped every freshly-fetched IP.** The ipinfo SDK
-  returns fresh batch entries as raw `dict`s (only cache/bogon hits are
-  `Details` objects), but `ipinfo_batch_lookup` kept entries only
-  `if hasattr(details, "all")` — so `ipinfo_lookup_ips` with 2+ uncached IPs
-  returned `[]`. The parser now accepts both shapes. (Single-IP lookups were
-  unaffected; the unit mock returned `Details` objects, masking it — the mock
-  now mirrors the real raw-dict shape, and a live multi-IP smoke test guards
-  the integration path.)
-- `ToolErrorEnvelope.request_id` is now populated with a server-generated
-  correlation id (uuid4 hex) on every raised error; previously always `null`.
 
 ### Added
 - `ipinfo_summarize_ips(ips, group_by=("country", "asn"), top_n=50)` for
@@ -45,20 +33,17 @@ returned nothing on a cold cache.
   per-IP lookups or a Core+ upgrade instead of retrying a call that can never
   succeed. A batch whose entries were returned but all failed to parse stays a
   retryable `api_error`. (#52)
-- `serverInfo.version` now reports the package version (e.g. `0.5.0`) via
+- `serverInfo.version` now reports the package version (e.g. `0.6.0`) via
   `FastMCP(version=...)`; it previously leaked the FastMCP library version,
   defeating client-side capability fingerprinting and version gating.
 - `website_url` on the server for discoverability.
 - Per-tool `meta.error_codes` lists the stable codes each tool can raise, so
   agents see the branch set from tool introspection without parsing the
   server instructions.
-- `meta.removed_in = "0.6.0"` on the deprecated aliases (was prose-only).
 - `idempotentHint: true` annotation on all read-only tools.
 - A `format: "ip"` JSON Schema hint on IP-string inputs (non-enforcing; soft
   runtime validation still returns structured envelopes for bad input).
 - Coarse progress reporting (`ctx.report_progress`) on the batch lookup path.
-- Schema-level `minItems`/`maxItems` on the deprecated `get_ip_details` alias,
-  matching `ipinfo_lookup_ips`.
 
 ### Changed
 - **Breaking:** `ipinfo_lookup_ips` now defaults to `detail="summary"` (was
@@ -78,6 +63,18 @@ returned nothing on a cold cache.
   `ipinfo_check_residential_proxy`, and `ipinfo_generate_map_url` respectively.
   Note that `get_map_url` returned a bare URL string; `ipinfo_generate_map_url`
   returns a structured `MapResult`.
+
+### Fixed
+- **Batch lookups silently dropped every freshly-fetched IP.** The ipinfo SDK
+  returns fresh batch entries as raw `dict`s (only cache/bogon hits are
+  `Details` objects), but `ipinfo_batch_lookup` kept entries only
+  `if hasattr(details, "all")` — so `ipinfo_lookup_ips` with 2+ uncached IPs
+  returned `[]`. The parser now accepts both shapes. (Single-IP lookups were
+  unaffected; the unit mock returned `Details` objects, masking it — the mock
+  now mirrors the real raw-dict shape, and a live multi-IP smoke test guards
+  the integration path.)
+- `ToolErrorEnvelope.request_id` is now populated with a server-generated
+  correlation id (uuid4 hex) on every raised error; previously always `null`.
 
 ## [0.5.0] - 2026-05-10
 

--- a/README.md
+++ b/README.md
@@ -52,11 +52,6 @@ To run the latest from `main`:
 
 Every tool raises a `ToolError` whose message is a JSON-encoded envelope with a stable `code` (`invalid_ip_address`, `special_ip_unsupported`, `no_valid_ips`, `too_many_ips`, `auth_invalid`, `auth_insufficient_scope`, `quota_exceeded`, `timeout`, `api_error`, `unknown_error`), a `temporary` flag, optional `retry_after_ms`, a `repair` hint, and a `request_id` correlation id. Agents should parse the message as JSON and branch on `code`. Each tool also advertises the subset of codes it can raise via `meta.error_codes`, so you can see the branch set from tool introspection.
 
-### Deprecated tools
-
-`get_ip_details`, `get_residential_proxy_info`, and `get_map_url` are forwarding aliases retained from 0.4.x. They are tagged `deprecated` and **will be removed in 0.6.0**. New code should call the `ipinfo_*` tools directly.
-
-
 ## Configuration
 
 ### Environment Variables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-ipinfo"
-version = "0.5.0"
+version = "0.6.0"
 description = "IP Geolocation Server for MCP"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/mcp_server_ipinfo/server.py
+++ b/src/mcp_server_ipinfo/server.py
@@ -91,9 +91,6 @@ mcp = FastMCP(
     - ipinfo_generate_map_url(ips): returns a MapResult
       {url, mapped_ip_count, skipped_ips (capped at 100), skipped_count, truncated}.
 
-    Deprecated forwarding aliases, removed in 0.6.0: get_ip_details,
-    get_residential_proxy_info, get_map_url.
-
     NOT in scope: DNS/hostname resolution; CIDR or BGP lookups; historical or
     time-series data; private/loopback/multicast/link-local/reserved IPs
     (filtered at boundary as `special_ip_unsupported`); deanonymizing users
@@ -690,10 +687,7 @@ async def _do_batch_lookup(
     ips: list[str],
     ctx: Context,
 ) -> list[IPDetails]:
-    """Validate, dedupe, cache-check, and look up a batch of IPs.
-
-    Shared between ipinfo_lookup_ips and the deprecated get_ip_details alias.
-    """
+    """Validate, dedupe, cache-check, and look up a batch of IPs."""
     return (await _do_batch_lookup_with_accounting(handler, cache, ips, ctx)).records
 
 
@@ -1103,126 +1097,3 @@ async def ipinfo_generate_map_url(
             "truncated": truncated,
         }
     )
-
-
-# --- Deprecated aliases ------------------------------------------------------
-#
-# Old tool names from <= 0.4.x. They forward to the new tools so cached MCP
-# clients still work for one minor version. Removed in 0.6.0.
-
-
-@mcp.tool(
-    annotations={
-        "readOnlyHint": True,
-        "openWorldHint": True,
-        "idempotentHint": True,
-    },
-    tags={"deprecated"},
-    meta={
-        "deprecated_since": "0.5.0",
-        "replaced_by": "ipinfo_lookup_ips",
-        "removed_in": "0.6.0",
-        # Forwards to the my_ip and batch paths; the list set is the superset of
-        # both (my_ip raises only upstream codes), so it covers either branch.
-        "error_codes": _LIST_TOOL_ERROR_CODES,
-    },
-)
-async def get_ip_details(
-    ips: Annotated[
-        list[IPString] | None,
-        Field(
-            description=(
-                "[DEPRECATED in 0.5.0; use ipinfo_lookup_my_ip when ips is None, "
-                "or ipinfo_lookup_ips otherwise. Removed in 0.6.0.] "
-                "IP address(es) to analyze (IPv4 or IPv6). Pass a list of one or "
-                "more IPs. If not provided, analyzes the requesting client's IP "
-                "address."
-            ),
-            min_length=1,
-            max_length=MAX_LOOKUP_IPS,
-            examples=[["8.8.8.8"], ["8.8.8.8", "1.1.1.1", "208.67.222.222"]],
-        ),
-    ] = None,
-    ctx: Context = CurrentContext(),
-) -> list[IPDetails]:
-    """[DEPRECATED in 0.5.0 — use ipinfo_lookup_my_ip / ipinfo_lookup_ips. Removed in 0.6.0.]
-
-    Forwards to ipinfo_lookup_my_ip when called with no `ips` (or `ips=None`),
-    and to ipinfo_lookup_ips otherwise. Behavior is otherwise unchanged.
-    """
-    handler, cache = _get_handler_and_cache(ctx)
-    if ips is None:
-        return [await _do_my_ip_lookup(handler, cache, ctx)]
-    return await _do_batch_lookup(handler, cache, ips, ctx)
-
-
-@mcp.tool(
-    annotations={
-        "readOnlyHint": True,
-        "openWorldHint": True,
-        "idempotentHint": True,
-    },
-    tags={"deprecated"},
-    meta={
-        "deprecated_since": "0.5.0",
-        "replaced_by": "ipinfo_check_residential_proxy",
-        "removed_in": "0.6.0",
-        "error_codes": _SINGLE_IP_TOOL_ERROR_CODES,
-    },
-)
-async def get_residential_proxy_info(
-    ip: Annotated[
-        str,
-        Field(
-            description=(
-                "[DEPRECATED in 0.5.0; use ipinfo_check_residential_proxy. Removed "
-                "in 0.6.0.] The IP address to check for residential proxy usage "
-                "(IPv4 or IPv6)."
-            ),
-            examples=["142.250.80.46"],
-        ),
-    ],
-    ctx: Context = CurrentContext(),
-) -> ResidentialProxyDetails:
-    """[DEPRECATED in 0.5.0 — use ipinfo_check_residential_proxy. Removed in 0.6.0.]"""
-    return await ipinfo_check_residential_proxy(ip=ip, ctx=ctx)
-
-
-@mcp.tool(
-    annotations={
-        "readOnlyHint": True,
-        "openWorldHint": True,
-        "idempotentHint": True,
-    },
-    tags={"deprecated"},
-    meta={
-        "deprecated_since": "0.5.0",
-        "replaced_by": "ipinfo_generate_map_url",
-        "removed_in": "0.6.0",
-        "error_codes": _LIST_TOOL_ERROR_CODES,
-    },
-)
-async def get_map_url(
-    ips: Annotated[
-        list[IPString],
-        Field(
-            description=(
-                "[DEPRECATED in 0.5.0; use ipinfo_generate_map_url. Removed in "
-                "0.6.0.] List of IP addresses to visualize on a map (IPv4 or "
-                "IPv6). Maximum 500,000 IPs."
-            ),
-            min_length=1,
-            max_length=MAX_LOOKUP_IPS,
-            examples=[["8.8.8.8", "1.1.1.1", "208.67.222.222"]],
-        ),
-    ],
-    ctx: Context = CurrentContext(),
-) -> str:
-    """[DEPRECATED in 0.5.0 — use ipinfo_generate_map_url. Removed in 0.6.0.]
-
-    Returns just the bare map URL string for 0.4.x cached-client parity.
-    Callers wanting structured skip/truncation metadata should call
-    ipinfo_generate_map_url directly.
-    """
-    result = await ipinfo_generate_map_url(ips=ips, ctx=ctx)
-    return str(result.url)

--- a/tests/smoke/test_live_tools.py
+++ b/tests/smoke/test_live_tools.py
@@ -187,18 +187,6 @@ async def test_generate_map_url_sentinel_and_dupe_accounting(client):
     assert "private" in skipped_reasons.get("192.168.1.1", "").lower()
 
 
-async def test_deprecated_get_map_url_alias_still_works(client):
-    """Forwarding alias preserves the bare-string return for 0.4.x parity."""
-    try:
-        r = await client.call_tool("get_map_url", arguments={"ips": ["8.8.8.8"]})
-    except ToolError as e:
-        _skip_if_transient(e)
-    # Bare-string return — FastMCP wraps non-object roots in {"result": "<url>"}.
-    url = r.structured_content["result"]
-    assert isinstance(url, str)
-    assert url.startswith("https://ipinfo.io/")
-
-
 async def test_structured_error_envelope_on_invalid_input(client):
     """No live API call — pure boundary rejection. Verifies envelope shape."""
     with pytest.raises(ToolError) as excinfo:

--- a/tests/test_error_dispatch.py
+++ b/tests/test_error_dispatch.py
@@ -13,9 +13,9 @@ from ipinfo.error import APIError
 from ipinfo.exceptions import RequestQuotaExceededError, TimeoutExceededError
 
 from mcp_server_ipinfo.server import (
-    get_ip_details,
-    get_map_url,
-    get_residential_proxy_info,
+    ipinfo_check_residential_proxy,
+    ipinfo_generate_map_url,
+    ipinfo_lookup_ips,
 )
 
 
@@ -29,7 +29,7 @@ class TestValidationErrorCodes:
 
     async def test_invalid_ip_format(self, mock_context_with_state):
         with pytest.raises(ToolError) as excinfo:
-            await get_residential_proxy_info(
+            await ipinfo_check_residential_proxy(
                 ip="not-an-ip", ctx=mock_context_with_state
             )
         env = parse_envelope(excinfo)
@@ -40,7 +40,7 @@ class TestValidationErrorCodes:
 
     async def test_private_ip_code(self, mock_context_with_state):
         with pytest.raises(ToolError) as excinfo:
-            await get_residential_proxy_info(
+            await ipinfo_check_residential_proxy(
                 ip="192.168.1.1", ctx=mock_context_with_state
             )
         env = parse_envelope(excinfo)
@@ -52,7 +52,7 @@ class TestValidationErrorCodes:
 
     async def test_no_valid_ips_code(self, mock_context_with_state):
         with pytest.raises(ToolError) as excinfo:
-            await get_ip_details(
+            await ipinfo_lookup_ips(
                 ips=["192.168.1.1", "10.0.0.1"], ctx=mock_context_with_state
             )
         env = parse_envelope(excinfo)
@@ -66,7 +66,7 @@ class TestValidationErrorCodes:
         # the same branch with O(1) memory per element instead of O(N).
         ips = ["1.1.1.1"] * 500_001
         with pytest.raises(ToolError) as excinfo:
-            await get_map_url(ips=ips, ctx=mock_context_with_state)
+            await ipinfo_generate_map_url(ips=ips, ctx=mock_context_with_state)
         env = parse_envelope(excinfo)
         assert env["code"] == "too_many_ips"
         assert env["temporary"] is False
@@ -78,21 +78,10 @@ class TestValidationErrorCodes:
         Schema enforces the cap at the FastMCP boundary, but direct Python
         invocation skips that path; the inner _do_batch_lookup guard catches it.
         """
-        from mcp_server_ipinfo.server import ipinfo_lookup_ips
 
         ips = ["1.1.1.1"] * 500_001
         with pytest.raises(ToolError) as excinfo:
             await ipinfo_lookup_ips(ips=ips, ctx=mock_context_with_state)
-        env = parse_envelope(excinfo)
-        assert env["code"] == "too_many_ips"
-
-    async def test_deprecated_get_ip_details_inherits_cap(
-        self, mock_context_with_state
-    ):
-        """The deprecated alias forwards to _do_batch_lookup so it inherits the cap."""
-        ips = ["1.1.1.1"] * 500_001
-        with pytest.raises(ToolError) as excinfo:
-            await get_ip_details(ips=ips, ctx=mock_context_with_state)
         env = parse_envelope(excinfo)
         assert env["code"] == "too_many_ips"
 
@@ -107,7 +96,7 @@ class TestUpstreamErrorCodes:
             side_effect=APIError(401, {"error": {"message": "Wrong token"}}),
         ):
             with pytest.raises(ToolError) as excinfo:
-                await get_ip_details(ips=["8.8.8.8"], ctx=mock_context_with_state)
+                await ipinfo_lookup_ips(ips=["8.8.8.8"], ctx=mock_context_with_state)
         env = parse_envelope(excinfo)
         assert env["code"] == "auth_invalid"
         assert env["temporary"] is False
@@ -121,7 +110,7 @@ class TestUpstreamErrorCodes:
             side_effect=APIError(403, {"error": {"message": "Plan required"}}),
         ):
             with pytest.raises(ToolError) as excinfo:
-                await get_residential_proxy_info(
+                await ipinfo_check_residential_proxy(
                     ip="142.250.80.46", ctx=mock_context_with_state
                 )
         env = parse_envelope(excinfo)
@@ -134,7 +123,7 @@ class TestUpstreamErrorCodes:
             side_effect=APIError(500, {"error": {"message": "boom"}}),
         ):
             with pytest.raises(ToolError) as excinfo:
-                await get_ip_details(ips=["8.8.8.8"], ctx=mock_context_with_state)
+                await ipinfo_lookup_ips(ips=["8.8.8.8"], ctx=mock_context_with_state)
         env = parse_envelope(excinfo)
         assert env["code"] == "api_error"
         assert env["temporary"] is True
@@ -145,7 +134,7 @@ class TestUpstreamErrorCodes:
             side_effect=RequestQuotaExceededError(),
         ):
             with pytest.raises(ToolError) as excinfo:
-                await get_ip_details(ips=["8.8.8.8"], ctx=mock_context_with_state)
+                await ipinfo_lookup_ips(ips=["8.8.8.8"], ctx=mock_context_with_state)
         env = parse_envelope(excinfo)
         assert env["code"] == "quota_exceeded"
         assert env["temporary"] is True
@@ -156,7 +145,7 @@ class TestUpstreamErrorCodes:
             side_effect=TimeoutExceededError(),
         ):
             with pytest.raises(ToolError) as excinfo:
-                await get_ip_details(ips=["8.8.8.8"], ctx=mock_context_with_state)
+                await ipinfo_lookup_ips(ips=["8.8.8.8"], ctx=mock_context_with_state)
         env = parse_envelope(excinfo)
         assert env["code"] == "timeout"
         assert env["temporary"] is True
@@ -168,7 +157,7 @@ class TestUpstreamErrorCodes:
             side_effect=RuntimeError("???"),
         ):
             with pytest.raises(ToolError) as excinfo:
-                await get_ip_details(ips=["8.8.8.8"], ctx=mock_context_with_state)
+                await ipinfo_lookup_ips(ips=["8.8.8.8"], ctx=mock_context_with_state)
         env = parse_envelope(excinfo)
         assert env["code"] == "unknown_error"
         assert env["temporary"] is True
@@ -180,7 +169,7 @@ class TestUpstreamErrorCodes:
             side_effect=RequestQuotaExceededError(),
         ):
             with pytest.raises(ToolError) as excinfo:
-                await get_ip_details(
+                await ipinfo_lookup_ips(
                     ips=["8.8.8.8", "1.1.1.1"], ctx=mock_context_with_state
                 )
         env = parse_envelope(excinfo)
@@ -194,7 +183,7 @@ class TestUpstreamErrorCodes:
             side_effect=APIError(404, {"error": {"message": "missing"}}),
         ):
             with pytest.raises(ToolError) as excinfo:
-                await get_ip_details(ips=["8.8.8.8"], ctx=mock_context_with_state)
+                await ipinfo_lookup_ips(ips=["8.8.8.8"], ctx=mock_context_with_state)
         env = parse_envelope(excinfo)
         assert env["code"] == "api_error"
         assert env["temporary"] is False
@@ -219,7 +208,9 @@ class TestUpstreamErrorCodes:
                 side_effect=RuntimeError("network down")
             )
             with pytest.raises(ToolError) as excinfo:
-                await get_map_url(ips=["8.8.8.8"], ctx=mock_context_with_state)
+                await ipinfo_generate_map_url(
+                    ips=["8.8.8.8"], ctx=mock_context_with_state
+                )
         env = parse_envelope(excinfo)
         # Map errors come from httpx, not the ipinfo library — they land in
         # the generic api_error/unknown bucket but must still be structured.

--- a/tests/test_map_result.py
+++ b/tests/test_map_result.py
@@ -2,8 +2,6 @@
 
 `ipinfo_generate_map_url` now returns a typed MapResult with the URL, the
 count that made the map, the list of IPs filtered out, and a truncated flag.
-The deprecated `get_map_url` alias keeps the bare `str` return shape for
-0.4.x cached-client parity.
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -201,24 +199,6 @@ class TestIpinfoGenerateMapUrlReturnsStructured:
         assert result.skipped_count == 150
         assert len(result.skipped_ips) == 100
         assert result.truncated is True
-
-
-class TestDeprecatedGetMapUrlPreservesStringReturn:
-    """The deprecated get_map_url alias keeps the 0.4.x bare-URL return shape."""
-
-    async def test_alias_returns_string(
-        self, mock_context_with_state, mock_httpx_response
-    ):
-        from mcp_server_ipinfo.server import get_map_url
-
-        with patch("mcp_server_ipinfo.ipinfo.httpx.AsyncClient") as mock_client:
-            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
-                return_value=mock_httpx_response
-            )
-            url = await get_map_url(ips=["8.8.8.8"], ctx=mock_context_with_state)
-
-        assert isinstance(url, str)
-        assert url == "https://ipinfo.io/map/demo/abc123"
 
 
 class TestHttpxErrorClassification:

--- a/tests/test_split_tools.py
+++ b/tests/test_split_tools.py
@@ -1,14 +1,11 @@
-"""Tests for the split tools introduced in 0.5.0.
+"""Tests for the split lookup tools introduced in 0.5.0.
 
-`get_ip_details` is split into:
+The original single `get_ip_details` tool was split into:
 - `ipinfo_lookup_my_ip()` — no args; the calling client's IP.
 - `ipinfo_lookup_ips(ips, detail="summary")` — list lookup; summary omits heavy blocks.
 
-The original `get_ip_details` is retained as a deprecated alias.
+The legacy alias was removed in 0.6.0.
 """
-
-import pytest
-from fastmcp.exceptions import ToolError
 
 from mcp_server_ipinfo.models import IPDetails
 
@@ -139,33 +136,3 @@ class TestRenamedTools:
         assert isinstance(result, MapResult)
         assert str(result.url) == "https://ipinfo.io/map/demo/xyz"
         assert result.mapped_ip_count == 2
-
-
-class TestDeprecatedGetIpDetails:
-    """The original get_ip_details remains as a deprecated alias."""
-
-    async def test_alias_still_callable(self, mock_context_with_state):
-        from mcp_server_ipinfo.server import get_ip_details
-
-        results = await get_ip_details(ips=["8.8.8.8"], ctx=mock_context_with_state)
-        assert len(results) == 1
-        assert str(results[0].ip) == "8.8.8.8"
-
-    async def test_alias_my_ip_mode(self, mock_context_with_state):
-        """get_ip_details(ips=None) preserves the legacy self-IP shortcut."""
-        from mcp_server_ipinfo.server import get_ip_details
-
-        results = await get_ip_details(ips=None, ctx=mock_context_with_state)
-        assert len(results) == 1
-        assert str(results[0].ip) == "203.0.113.1"
-
-    async def test_no_valid_ips_envelope(self, mock_context_with_state):
-        """The deprecated alias still emits structured envelopes on validation failures."""
-        import json
-
-        from mcp_server_ipinfo.server import get_ip_details
-
-        with pytest.raises(ToolError) as excinfo:
-            await get_ip_details(ips=["192.168.1.1"], ctx=mock_context_with_state)
-        env = json.loads(str(excinfo.value))
-        assert env["code"] == "no_valid_ips"

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -78,45 +78,6 @@ class TestNewToolSchemas:
         assert tool.parameters.get("required", []) == []
 
 
-class TestDeprecationMetadata:
-    """Deprecated aliases carry tags + meta so cached clients can detect them."""
-
-    @pytest.mark.parametrize(
-        ("name", "replacement"),
-        [
-            ("get_ip_details", "ipinfo_lookup_ips"),
-            ("get_residential_proxy_info", "ipinfo_check_residential_proxy"),
-            ("get_map_url", "ipinfo_generate_map_url"),
-        ],
-    )
-    async def test_alias_marked_deprecated(self, registered_tools, name, replacement):
-        tool = registered_tools[name]
-        assert "deprecated" in (tool.tags or set())
-        assert tool.meta is not None
-        assert tool.meta.get("deprecated_since") == "0.5.0"
-        assert tool.meta.get("replaced_by") == replacement
-
-    @pytest.mark.parametrize(
-        "name",
-        ["get_ip_details", "get_residential_proxy_info", "get_map_url"],
-    )
-    async def test_alias_carries_removal_version(self, registered_tools, name):
-        """removed_in is structured meta, not just prose, so clients can gate on it."""
-        tool = registered_tools[name]
-        assert tool.meta.get("removed_in") == "0.6.0"
-
-    async def test_deprecated_list_alias_keeps_array_constraints(
-        self, registered_tools
-    ):
-        """get_ip_details forwards to the batch path, so it carries the same cap."""
-        tool = registered_tools["get_ip_details"]
-        ips_schema = tool.parameters["properties"]["ips"]
-        # Optional[list] nests the array constraints inside an anyOf branch.
-        array_branch = next(b for b in ips_schema["anyOf"] if b.get("type") == "array")
-        assert array_branch["minItems"] == 1
-        assert array_branch["maxItems"] == 500_000
-
-
 class TestToolContract:
     """Agent-facing contract metadata: error codes, idempotency hints."""
 
@@ -169,25 +130,6 @@ class TestToolContract:
         codes = set(registered_tools[name].meta["error_codes"])
         assert "invalid_ip_address" not in codes
         assert "special_ip_unsupported" not in codes
-
-    @pytest.mark.parametrize(
-        ("name", "expected"),
-        [
-            ("get_ip_details", {"no_valid_ips", "too_many_ips", "api_error"}),
-            (
-                "get_residential_proxy_info",
-                {"invalid_ip_address", "auth_insufficient_scope"},
-            ),
-            ("get_map_url", {"no_valid_ips", "timeout"}),
-        ],
-    )
-    async def test_deprecated_aliases_advertise_error_codes(
-        self, registered_tools, name, expected
-    ):
-        """Aliases forward to tools that raise structured errors, so their meta
-        must carry the same error_codes contract as the replacements."""
-        codes = set(registered_tools[name].meta.get("error_codes", []))
-        assert expected <= codes, f"{name} missing {expected - codes}"
 
     @pytest.mark.parametrize(
         "name",

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -78,6 +78,22 @@ class TestNewToolSchemas:
         assert tool.parameters.get("required", []) == []
 
 
+class TestRemovedAliases:
+    """The 0.5.0 forwarding aliases were removed in 0.6.0 and must stay gone.
+
+    Guards the removal contract: an accidental reintroduction of any legacy
+    name would otherwise pass silently, since every other contract test only
+    asserts the surviving tools by positive lookup.
+    """
+
+    @pytest.mark.parametrize(
+        "name",
+        ["get_ip_details", "get_residential_proxy_info", "get_map_url"],
+    )
+    async def test_alias_absent_from_registry(self, registered_tools, name):
+        assert name not in registered_tools
+
+
 class TestToolContract:
     """Agent-facing contract metadata: error codes, idempotency hints."""
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -8,9 +8,9 @@ from fastmcp.exceptions import ToolError
 from mcp_server_ipinfo.server import (
     _normalize_ip,
     _validate_ip,
-    get_ip_details,
-    get_map_url,
-    get_residential_proxy_info,
+    ipinfo_check_residential_proxy,
+    ipinfo_generate_map_url,
+    ipinfo_lookup_ips,
 )
 
 
@@ -105,12 +105,14 @@ class TestNormalizeIP:
         assert _normalize_ip(input_ip) == expected
 
 
-class TestGetIPDetails:
-    """Tests for get_ip_details tool."""
+class TestLookupIps:
+    """Tests for ipinfo_lookup_ips tool (detail="full" to assert on model fields)."""
 
     async def test_lookup_single_ip(self, mock_context_with_state):
         """Test looking up a single IP."""
-        results = await get_ip_details(ips=["8.8.8.8"], ctx=mock_context_with_state)
+        results = await ipinfo_lookup_ips(
+            ips=["8.8.8.8"], detail="full", ctx=mock_context_with_state
+        )
 
         assert len(results) == 1
         assert str(results[0].ip) == "8.8.8.8"
@@ -119,26 +121,22 @@ class TestGetIPDetails:
     async def test_lookup_multiple_ips(self, mock_context_with_state):
         """Test looking up multiple IPs."""
         ips = ["8.8.8.8", "1.1.1.1"]
-        results = await get_ip_details(ips=ips, ctx=mock_context_with_state)
+        results = await ipinfo_lookup_ips(
+            ips=ips, detail="full", ctx=mock_context_with_state
+        )
 
         assert len(results) == 2
         result_ips = {str(r.ip) for r in results}
         assert result_ips == {"8.8.8.8", "1.1.1.1"}
-
-    async def test_lookup_client_ip(self, mock_context_with_state):
-        """Test looking up client's own IP (None)."""
-        results = await get_ip_details(ips=None, ctx=mock_context_with_state)
-
-        assert len(results) == 1
-        # Mock returns 203.0.113.1 for None
-        assert str(results[0].ip) == "203.0.113.1"
 
     async def test_cache_hit(self, mock_context_with_state, sample_ip_details):
         """Test that cached results are returned."""
         cache = mock_context_with_state.lifespan_context["cache"]
         await cache.set("8.8.8.8", sample_ip_details)
 
-        results = await get_ip_details(ips=["8.8.8.8"], ctx=mock_context_with_state)
+        results = await ipinfo_lookup_ips(
+            ips=["8.8.8.8"], detail="full", ctx=mock_context_with_state
+        )
 
         assert len(results) == 1
         assert results[0] is sample_ip_details
@@ -146,17 +144,23 @@ class TestGetIPDetails:
     async def test_invalid_ip(self, mock_context_with_state):
         """Test that all invalid IPs raise ToolError."""
         with pytest.raises(ToolError, match="No valid IP addresses"):
-            await get_ip_details(ips=["not-an-ip"], ctx=mock_context_with_state)
+            await ipinfo_lookup_ips(
+                ips=["not-an-ip"], detail="full", ctx=mock_context_with_state
+            )
 
     async def test_private_ip(self, mock_context_with_state):
         """Test that all private IPs raise ToolError."""
         with pytest.raises(ToolError, match="No valid IP addresses"):
-            await get_ip_details(ips=["192.168.1.1"], ctx=mock_context_with_state)
+            await ipinfo_lookup_ips(
+                ips=["192.168.1.1"], detail="full", ctx=mock_context_with_state
+            )
 
     async def test_mixed_valid_invalid_ips(self, mock_context_with_state):
         """Test batch skips invalid IPs with warnings."""
         ips = ["8.8.8.8", "192.168.1.1", "1.1.1.1"]
-        results = await get_ip_details(ips=ips, ctx=mock_context_with_state)
+        results = await ipinfo_lookup_ips(
+            ips=ips, detail="full", ctx=mock_context_with_state
+        )
 
         # Only public IPs should be returned
         assert len(results) == 2
@@ -171,7 +175,7 @@ class TestGetIPDetails:
         ips = ["192.168.1.1", "10.0.0.1", "127.0.0.1"]
 
         with pytest.raises(ToolError, match="No valid IP addresses"):
-            await get_ip_details(ips=ips, ctx=mock_context_with_state)
+            await ipinfo_lookup_ips(ips=ips, detail="full", ctx=mock_context_with_state)
 
     async def test_with_cache(self, mock_context_with_state, sample_ip_details):
         """Test uses cache for known IPs."""
@@ -179,7 +183,9 @@ class TestGetIPDetails:
         await cache.set("8.8.8.8", sample_ip_details)
 
         ips = ["8.8.8.8", "1.1.1.1"]
-        results = await get_ip_details(ips=ips, ctx=mock_context_with_state)
+        results = await ipinfo_lookup_ips(
+            ips=ips, detail="full", ctx=mock_context_with_state
+        )
 
         assert len(results) == 2
         # 8.8.8.8 should be the cached version
@@ -189,7 +195,9 @@ class TestGetIPDetails:
     async def test_preserves_order(self, mock_context_with_state):
         """Test that results preserve input order where possible."""
         ips = ["8.8.8.8", "1.1.1.1", "208.67.222.222"]
-        results = await get_ip_details(ips=ips, ctx=mock_context_with_state)
+        results = await ipinfo_lookup_ips(
+            ips=ips, detail="full", ctx=mock_context_with_state
+        )
 
         result_ips = [str(r.ip) for r in results]
         assert result_ips == ips
@@ -197,8 +205,8 @@ class TestGetIPDetails:
     async def test_normalized_inputs(self, mock_context_with_state):
         """Test that placeholder values are filtered out."""
         # Only the valid IP should be looked up
-        results = await get_ip_details(
-            ips=["8.8.8.8", "", "null"], ctx=mock_context_with_state
+        results = await ipinfo_lookup_ips(
+            ips=["8.8.8.8", "", "null"], detail="full", ctx=mock_context_with_state
         )
         assert len(results) == 1
         assert str(results[0].ip) == "8.8.8.8"
@@ -206,33 +214,39 @@ class TestGetIPDetails:
     async def test_empty_list_after_normalization(self, mock_context_with_state):
         """Test error when all IPs normalize to None."""
         with pytest.raises(ToolError, match="No valid IP addresses"):
-            await get_ip_details(
-                ips=["", "null", "undefined"], ctx=mock_context_with_state
+            await ipinfo_lookup_ips(
+                ips=["", "null", "undefined"],
+                detail="full",
+                ctx=mock_context_with_state,
             )
 
     async def test_duplicate_ips_deduplicated(self, mock_context_with_state):
         """Test that duplicate IPs are deduplicated."""
-        results = await get_ip_details(
-            ips=["8.8.8.8", "8.8.8.8", "8.8.8.8"], ctx=mock_context_with_state
+        results = await ipinfo_lookup_ips(
+            ips=["8.8.8.8", "8.8.8.8", "8.8.8.8"],
+            detail="full",
+            ctx=mock_context_with_state,
         )
         assert len(results) == 1
         assert str(results[0].ip) == "8.8.8.8"
 
     async def test_whitespace_stripped(self, mock_context_with_state):
         """Test that whitespace around IPs is stripped."""
-        results = await get_ip_details(ips=[" 8.8.8.8 "], ctx=mock_context_with_state)
+        results = await ipinfo_lookup_ips(
+            ips=[" 8.8.8.8 "], detail="full", ctx=mock_context_with_state
+        )
         assert len(results) == 1
         assert str(results[0].ip) == "8.8.8.8"
 
     # Upstream-error → structured envelope coverage lives in test_error_dispatch.py.
 
 
-class TestGetResidentialProxyInfo:
-    """Tests for get_residential_proxy_info tool."""
+class TestCheckResidentialProxy:
+    """Tests for ipinfo_check_residential_proxy tool."""
 
     async def test_lookup(self, mock_context_with_state):
         """Test residential proxy lookup."""
-        result = await get_residential_proxy_info(
+        result = await ipinfo_check_residential_proxy(
             ip="142.250.80.46", ctx=mock_context_with_state
         )
 
@@ -244,20 +258,20 @@ class TestGetResidentialProxyInfo:
     async def test_invalid_ip(self, mock_context_with_state):
         """Test that invalid IPs raise ToolError."""
         with pytest.raises(ToolError, match="not a valid IP address"):
-            await get_residential_proxy_info(
+            await ipinfo_check_residential_proxy(
                 ip="not-an-ip", ctx=mock_context_with_state
             )
 
     async def test_private_ip(self, mock_context_with_state):
         """Test that private IPs raise ToolError."""
         with pytest.raises(ToolError, match="private IP address"):
-            await get_residential_proxy_info(
+            await ipinfo_check_residential_proxy(
                 ip="192.168.1.1", ctx=mock_context_with_state
             )
 
 
-class TestGetMapUrl:
-    """Tests for get_map_url tool."""
+class TestGenerateMapUrl:
+    """Tests for ipinfo_generate_map_url tool."""
 
     @pytest.fixture
     def mock_httpx_response(self):
@@ -278,11 +292,11 @@ class TestGetMapUrl:
                 return_value=mock_httpx_response
             )
 
-            url = await get_map_url(
+            result = await ipinfo_generate_map_url(
                 ips=["8.8.8.8", "1.1.1.1"], ctx=mock_context_with_state
             )
 
-            assert url == "https://ipinfo.io/map/demo/abc123"
+            assert str(result.url) == "https://ipinfo.io/map/demo/abc123"
             mock_context_with_state.info.assert_called()
 
     async def test_filters_invalid_ips(
@@ -293,12 +307,12 @@ class TestGetMapUrl:
             mock_post = AsyncMock(return_value=mock_httpx_response)
             mock_client.return_value.__aenter__.return_value.post = mock_post
 
-            url = await get_map_url(
+            result = await ipinfo_generate_map_url(
                 ips=["8.8.8.8", "192.168.1.1", "1.1.1.1"],
                 ctx=mock_context_with_state,
             )
 
-            assert url == "https://ipinfo.io/map/demo/abc123"
+            assert str(result.url) == "https://ipinfo.io/map/demo/abc123"
             # Check that only valid IPs were sent
             call_args = mock_post.call_args
             sent_ips = call_args.kwargs.get("json") or call_args[1].get("json")
@@ -311,7 +325,7 @@ class TestGetMapUrl:
     async def test_all_invalid_ips_error(self, mock_context_with_state):
         """Test error when all IPs are invalid."""
         with pytest.raises(ToolError, match="No valid IP addresses"):
-            await get_map_url(
+            await ipinfo_generate_map_url(
                 ips=["192.168.1.1", "10.0.0.1"], ctx=mock_context_with_state
             )
 
@@ -323,12 +337,12 @@ class TestGetMapUrl:
             mock_post = AsyncMock(return_value=mock_httpx_response)
             mock_client.return_value.__aenter__.return_value.post = mock_post
 
-            url = await get_map_url(
+            result = await ipinfo_generate_map_url(
                 ips=["8.8.8.8", "", "null", "undefined"],
                 ctx=mock_context_with_state,
             )
 
-            assert url == "https://ipinfo.io/map/demo/abc123"
+            assert str(result.url) == "https://ipinfo.io/map/demo/abc123"
             call_args = mock_post.call_args
             sent_ips = call_args.kwargs.get("json") or call_args[1].get("json")
             assert sent_ips == ["8.8.8.8"]
@@ -343,4 +357,4 @@ class TestGetMapUrl:
         """
         ips = ["1.1.1.1"] * 500_001
         with pytest.raises(ToolError, match="Too many IPs"):
-            await get_map_url(ips=ips, ctx=mock_context_with_state)
+            await ipinfo_generate_map_url(ips=ips, ctx=mock_context_with_state)

--- a/uv.lock
+++ b/uv.lock
@@ -871,7 +871,7 @@ wheels = [
 
 [[package]]
 name = "mcp-server-ipinfo"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Cuts the **0.6.0** release. This release does two things:

1. **Hardens the agent-facing contract** (work already merged into `main` since `v0.5.0` — batch silent-drop fix B0, `request_id` population, `ipinfo_summarize_ips`, partial-batch failure surfacing, the breaking `detail="summary"` default, etc.).
2. **Completes the 0.5.0 deprecation cycle** by removing the three forwarding aliases that were stamped `removed_in: "0.6.0"`:
   - `get_ip_details` → use `ipinfo_lookup_my_ip` / `ipinfo_lookup_ips`
   - `get_residential_proxy_info` → use `ipinfo_check_residential_proxy`
   - `get_map_url` → use `ipinfo_generate_map_url` (note: returns a structured `MapResult`, not a bare URL string)

## Changes

- `pyproject.toml`: version `0.5.0` → `0.6.0`
- `CHANGELOG.md`: `[Unreleased]` folded into `[0.6.0] - 2026-05-31`, new `### Removed` section, compare links updated
- `server.py`: deleted the deprecated alias block and the alias references in the server instructions
- `README.md`: dropped the "Deprecated tools" section
- Tests: **retargeted** the behavior tests that used the aliases as an entry point onto the `ipinfo_*` tools (preserving validation/dedup/ordering/error-dispatch coverage); **removed** the forwarding-specific tests (alias deprecation metadata, bare-URL return shape, the live alias smoke check)

## Verification

- `ruff check` ✅ · `ruff format` ✅ · `ty check` ✅
- `uv run pytest` → **193 passed**, 9 smoke deselected, coverage **97.54%** (threshold 95%)
- Smoke suite collects cleanly (9 tests, no import errors)

> ⚠️ Breaking: removing the aliases is a breaking change for any client still calling the old tool names. Under 0.x SemVer this is a minor bump.

## Follow-up after merge

Tag `v0.6.0`, create the GitHub release, run the smoke suite with a token, then `uv build && uv publish` per `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)