### PR TITLE
docs: accurate release/publish flow in CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Conventions
+
+- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages.
+- Follow the [Keep a Changelog](https://keepachangelog.com/) format for CHANGELOG.md.
+
+## Releases
+
+Releases are automated by `.github/workflows/publish.yml`, which triggers on pushing a tag matching `v*`. The workflow runs the test suite, builds the package, publishes to PyPI via trusted publishing (OIDC — no API token needed), and creates the GitHub release with auto-generated notes and the built `dist/*` artifacts attached.
+
+To cut a release:
+
+1. Bump `version` in `pyproject.toml`, and fold the `CHANGELOG.md` `[Unreleased]` section into a new `[<version>] - <date>` heading (and update the compare links at the bottom).
+2. Run the smoke tests (see below) before tagging — the workflow runs the default suite but **not** the smoke suite.
+3. Merge to `main`, then tag and push: `git tag v<version> && git push origin v<version>` (the `v` prefix matters — it's what the workflow triggers on).
+
+Do **not** run `uv build` / `uv publish` by hand; pushing the tag does it. If you want curated release notes instead of the auto-generated ones, create or edit the GitHub release with the CHANGELOG section — the workflow attaches artifacts but does not overwrite an existing release body.
+
+## FastMCP Documentation
+
+Use the `mcp__fastmcp__search_fast_mcp` tool to search FastMCP documentation for API references, patterns, and examples when working on this codebase.
+
+## Smoke tests
+
+Live-API smoke tests in `tests/smoke/` exercise each production tool against the real IPInfo API. They are excluded from the default `pytest` run (via the `-m 'not smoke'` filter) and from the published wheel and sdist.
+
+Before tagging a release, run:
+
+    IPINFO_API_TOKEN=<your-token> uv run pytest -m smoke --no-cov
+
+Without the token the tests skip cleanly. Each run makes ~8 live API calls. The smoke suite catches upstream contract changes that mocked unit tests cannot.
+
+Transient upstream conditions auto-skip rather than fail: any envelope with `temporary: true` and a `code` in `{quota_exceeded, timeout, api_error}` (the last covers IPInfo 5xx). If a smoke test reports SKIPPED with a "transient envelope" reason, re-run it; only persistent failures should be filed as bugs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,15 @@
 
 ## Releases
 
-- Tag releases with the version prefixed by `v` (e.g., `v0.4.0`) and create GitHub releases from the tag.
-- After tagging, publish with `uv build && uv publish`.
+Releases are automated by `.github/workflows/publish.yml`, which triggers on pushing a tag matching `v*`. The workflow runs the test suite, builds the package, publishes to PyPI via trusted publishing (OIDC — no API token needed), and creates the GitHub release with auto-generated notes and the built `dist/*` artifacts attached.
+
+To cut a release:
+
+1. Bump `version` in `pyproject.toml`, and fold the `CHANGELOG.md` `[Unreleased]` section into a new `[<version>] - <date>` heading (and update the compare links at the bottom).
+2. Run the smoke tests (see below) before tagging — the workflow runs the default suite but **not** the smoke suite.
+3. Merge to `main`, then tag and push: `git tag v<version> && git push origin v<version>` (the `v` prefix matters — it's what the workflow triggers on).
+
+Do **not** run `uv build` / `uv publish` by hand; pushing the tag does it. If you want curated release notes instead of the auto-generated ones, create or edit the GitHub release with the CHANGELOG section — the workflow attaches artifacts but does not overwrite an existing release body.
 
 ## FastMCP Documentation
 
@@ -22,6 +29,6 @@ Before tagging a release, run:
 
     IPINFO_API_TOKEN=<your-token> uv run pytest -m smoke --no-cov
 
-Without the token the tests skip cleanly. Each run makes ~6 live API calls. The smoke suite catches upstream contract changes that mocked unit tests cannot.
+Without the token the tests skip cleanly. Each run makes ~8 live API calls. The smoke suite catches upstream contract changes that mocked unit tests cannot.
 
 Transient upstream conditions auto-skip rather than fail: any envelope with `temporary: true` and a `code` in `{quota_exceeded, timeout, api_error}` (the last covers IPInfo 5xx). If a smoke test reports SKIPPED with a "transient envelope" reason, re-run it; only persistent failures should be filed as bugs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,34 +1,3 @@
 # CLAUDE.md
 
-## Conventions
-
-- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages.
-- Follow the [Keep a Changelog](https://keepachangelog.com/) format for CHANGELOG.md.
-
-## Releases
-
-Releases are automated by `.github/workflows/publish.yml`, which triggers on pushing a tag matching `v*`. The workflow runs the test suite, builds the package, publishes to PyPI via trusted publishing (OIDC — no API token needed), and creates the GitHub release with auto-generated notes and the built `dist/*` artifacts attached.
-
-To cut a release:
-
-1. Bump `version` in `pyproject.toml`, and fold the `CHANGELOG.md` `[Unreleased]` section into a new `[<version>] - <date>` heading (and update the compare links at the bottom).
-2. Run the smoke tests (see below) before tagging — the workflow runs the default suite but **not** the smoke suite.
-3. Merge to `main`, then tag and push: `git tag v<version> && git push origin v<version>` (the `v` prefix matters — it's what the workflow triggers on).
-
-Do **not** run `uv build` / `uv publish` by hand; pushing the tag does it. If you want curated release notes instead of the auto-generated ones, create or edit the GitHub release with the CHANGELOG section — the workflow attaches artifacts but does not overwrite an existing release body.
-
-## FastMCP Documentation
-
-Use the `mcp__fastmcp__search_fast_mcp` tool to search FastMCP documentation for API references, patterns, and examples when working on this codebase.
-
-## Smoke tests
-
-Live-API smoke tests in `tests/smoke/` exercise each production tool against the real IPInfo API. They are excluded from the default `pytest` run (via the `-m 'not smoke'` filter) and from the published wheel and sdist.
-
-Before tagging a release, run:
-
-    IPINFO_API_TOKEN=<your-token> uv run pytest -m smoke --no-cov
-
-Without the token the tests skip cleanly. Each run makes ~8 live API calls. The smoke suite catches upstream contract changes that mocked unit tests cannot.
-
-Transient upstream conditions auto-skip rather than fail: any envelope with `temporary: true` and a `code` in `{quota_exceeded, timeout, api_error}` (the last covers IPInfo 5xx). If a smoke test reports SKIPPED with a "transient envelope" reason, re-run it; only persistent failures should be filed as bugs.
+Claude should follow the project instructions in [AGENTS.md](./AGENTS.md).


### PR DESCRIPTION
## Summary

`CLAUDE.md`'s **Releases** section was inaccurate: it said to publish with a manual `uv build && uv publish`. The repo actually publishes via `.github/workflows/publish.yml`, which triggers on pushing a `v*` tag and:

1. `uv sync --extra dev` → `uv run pytest`
2. `uv build`
3. `uv publish` (PyPI **trusted publishing** — `environment: pypi`, `id-token: write`, no API token)
4. `softprops/action-gh-release` — creates the GitHub release with generated notes and uploads `dist/*`

This was confirmed against the just-shipped 0.6.0: the `v0.6.0` tag push ran the workflow to success, PyPI now serves `0.6.0` (wheel + sdist), and the GitHub release carries the built artifacts.

## Changes

- Rewrite **Releases** around the tag-push trigger; document the real human steps (bump version, update CHANGELOG, run smoke, merge, tag & push) and drop the manual-publish instruction.
- Note the curated-notes nuance: the workflow attaches artifacts but does not overwrite an existing release body, so hand-written CHANGELOG notes survive.
- Correct the smoke-suite live-call count (`~6` → `~8`) — 8 of the 9 smoke tests make a live API call (the boundary-rejection test makes none).

Docs-only; no code or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)