### PR TITLE
feat: package server as an MCPB bundle for one-click install

### DIFF
--- a/.github/workflows/mcpb.yml
+++ b/.github/workflows/mcpb.yml
@@ -1,0 +1,74 @@
+name: Build MCPB bundle
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag to attach the bundle to (e.g. v0.6.0)"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to (re)build and attach the bundle to"
+        required: true
+        type: string
+
+permissions:
+  contents: write # upload the .mcpb asset to the release
+
+jobs:
+  bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag }} # build the bundle from the tagged commit
+      - uses: astral-sh/setup-uv@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Sync project
+        run: uv sync --extra dev
+
+      - name: Verify manifest is in sync
+        run: uv run python scripts/gen_manifest.py --check
+
+      - name: Install mcpb CLI
+        run: npm install -g @anthropic-ai/mcpb@2.1.2 # pin for reproducible bundles
+
+      - name: Validate manifest
+        run: mcpb validate manifest.json
+
+      - name: Compute versioned bundle path
+        run: |
+          version="$(python3 -c 'import json; print(json.load(open("manifest.json"))["version"])')"
+          echo "BUNDLE=dist/mcp-server-ipinfo-${version}.mcpb" >> "$GITHUB_ENV"
+
+      - name: Pack bundle
+        run: |
+          mkdir -p dist
+          mcpb pack . "$BUNDLE"
+
+      - name: Assert bundle excludes secrets and dev files
+        run: |
+          contents="$(unzip -Z1 "$BUNDLE")"
+          echo "$contents"
+          if echo "$contents" | grep -E -i \
+            '(^|/)(\.env$|\.git/|\.github/|\.venv/|tests/|scripts/|prek\.toml$|CLAUDE\.md$|AGENTS\.md$|__pycache__/|\.coverage$|\.pytest_cache/|\.ruff_cache/)'; then
+            echo "::error::Forbidden path found in .mcpb bundle"
+            exit 1
+          fi
+
+      - name: Upload bundle to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }} # via env to avoid shell injection from the input
+        run: gh release upload "$TAG" "$BUNDLE" --clobber
+
+      - name: Upload bundle as workflow artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: mcp-server-ipinfo-mcpb
+          path: ${{ env.BUNDLE }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,23 +5,47 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: write
-  id-token: write
+permissions: {}
 
 jobs:
   publish:
     name: Build and publish
     runs-on: ubuntu-latest
     environment: pypi
+    permissions:
+      contents: write # create the GitHub release
+      id-token: write # OIDC trusted publishing; no API token needed
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
       - run: uv sync --extra dev
       - run: uv run pytest
+      - name: Tag matches pyproject version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pyproject_version="$(python3 -c 'import tomllib,pathlib; print(tomllib.load(pathlib.Path("pyproject.toml").open("rb"))["project"]["version"])')"
+          echo "tag=$tag pyproject=$pyproject_version"
+          if [ "$tag" != "$pyproject_version" ]; then
+            echo "::error::Version mismatch: tag=$tag pyproject=$pyproject_version. Bump pyproject.toml (and regenerate manifest.json) to match the tag."
+            exit 1
+          fi
+      # manifest.json is generated from pyproject + the server's tools; fail fast
+      # if it was not regenerated and committed (also enforced by the test suite).
+      - run: uv run python scripts/gen_manifest.py --check
       - run: uv build
       - run: uv publish
       - uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: dist/*
+
+  # Build and attach the .mcpb bundle after the release exists. Called
+  # explicitly (not via a release trigger) because a release created with
+  # GITHUB_TOKEN does not trigger other workflows.
+  bundle:
+    needs: publish
+    permissions:
+      contents: write # mcpb.yml uploads the .mcpb asset to the release
+    uses: ./.github/workflows/mcpb.yml
+    with:
+      tag: ${{ github.ref_name }}

--- a/.mcpbignore
+++ b/.mcpbignore
@@ -1,0 +1,37 @@
+# Keep the .mcpb bundle minimal: ship only what `uv run` needs at runtime
+# (manifest.json, pyproject.toml, uv.lock, src/, README.md, LICENSE).
+# Everything below must never end up in the archive — see the forbidden-paths
+# assertion in .github/workflows/mcpb.yml.
+
+.env
+.git/
+.github/
+.venv/
+dist/
+build/
+wheels/
+*.egg-info/
+
+# Tests, dev tooling, local scratch
+tests/
+scripts/
+prek.toml
+CLAUDE.md
+AGENTS.md
+CHANGELOG.md
+.agents/
+.claude/
+
+# Caches and build artifacts
+__pycache__/
+*.py[oc]
+.ruff_cache/
+.pytest_cache/
+.coverage
+*.mcpb
+
+# Misc
+.python-version
+.gitignore
+.mcpbignore
+.DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,11 +7,13 @@
 
 ## Releases
 
-Releases are automated by `.github/workflows/publish.yml`, which triggers on pushing a tag matching `v*`. The workflow runs the test suite, builds the package, publishes to PyPI via trusted publishing (OIDC — no API token needed), and creates the GitHub release with auto-generated notes and the built `dist/*` artifacts attached.
+Releases are automated by `.github/workflows/publish.yml`, which triggers on pushing a tag matching `v*`. The workflow runs the test suite, asserts the tag matches the `pyproject.toml` version, checks `manifest.json` is in sync, builds the package, publishes to PyPI via trusted publishing (OIDC — no API token needed), and creates the GitHub release with auto-generated notes and the built `dist/*` artifacts (wheel, sdist) attached. A dependent `bundle` job (reusable `.github/workflows/mcpb.yml`) then packs the MCPB bundle (`dist/mcp-server-ipinfo-<version>.mcpb`) for one-click Claude Desktop install and uploads it to the release.
+
+`manifest.json` is **generated** from `pyproject.toml` plus the server's registered tools by `scripts/gen_manifest.py` — do not hand-edit it. `tests/test_manifest.py` and the workflow both run `gen_manifest.py --check` to catch a stale committed manifest.
 
 To cut a release:
 
-1. Bump `version` in `pyproject.toml`, and fold the `CHANGELOG.md` `[Unreleased]` section into a new `[<version>] - <date>` heading (and update the compare links at the bottom).
+1. Bump `version` in `pyproject.toml`, regenerate the manifest with `uv run python scripts/gen_manifest.py`, and fold the `CHANGELOG.md` `[Unreleased]` section into a new `[<version>] - <date>` heading (and update the compare links at the bottom). The publish workflow asserts `tag == pyproject` and that the manifest is in sync, failing the release on a mismatch.
 2. Run the smoke tests (see below) before tagging — the workflow runs the default suite but **not** the smoke suite.
 3. Merge to `main`, then tag and push: `git tag v<version> && git push origin v<version>` (the `v` prefix matters — it's what the workflow triggers on).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- MCPB bundle packaging for one-click install in Claude Desktop. A `manifest.json`
+  (`server.type: "uv"`) is generated from `pyproject.toml` and the server's tools by
+  `scripts/gen_manifest.py` (drift-guarded by `tests/test_manifest.py`); the release
+  workflow packs a version-stamped `.mcpb` and attaches it to the GitHub release. The
+  token and cache settings are exposed as install-time `user_config`; leaving the token
+  blank runs the free Lite tier.
+
 ## [0.6.0] - 2026-05-31
 
 This cycle hardens the agent-facing contract from a joint Claude + Codex

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ A [Model Context Protocol](https://modelcontextprotocol.io) server that exposes 
 
 Sign up for a free IPInfo API token at <https://ipinfo.io/signup> if you don't have one. The server runs with no token (free Lite tier — country and ASN basics) but most fields require a token.
 
+### Claude Desktop (one-click bundle)
+
+Download the `.mcpb` bundle from the [latest release](https://github.com/briandconnelly/mcp-server-ipinfo/releases/latest) and open it to install in Claude Desktop. You can set your `IPINFO_API_TOKEN` (and optional cache tuning) in the install dialog; leave the token blank to run in the free Lite tier. The bundle launches the server with [`uv`](https://docs.astral.sh/uv/), so `uv` must be installed and on your system `PATH` (GUI apps don't inherit your shell's `PATH`).
+
+### Other MCP clients
+
 Most MCP clients accept the following values:
 
 | Field | Value |

--- a/manifest.json
+++ b/manifest.json
@@ -78,24 +78,24 @@
   },
   "tools": [
     {
-      "name": "ipinfo_lookup_my_ip",
-      "description": "Geolocate the calling client's own IP. No arguments."
-    },
-    {
-      "name": "ipinfo_lookup_ips",
-      "description": "Geolocate one or more IPs and return ISP/ASN details."
-    },
-    {
-      "name": "ipinfo_summarize_ips",
-      "description": "Aggregate one or more IP lookups into counts and percentages."
-    },
-    {
       "name": "ipinfo_check_residential_proxy",
       "description": "Classify whether an IP is a known residential-proxy exit node."
     },
     {
       "name": "ipinfo_generate_map_url",
       "description": "Build an interactive ipinfo.io map for a set of IPs."
+    },
+    {
+      "name": "ipinfo_lookup_ips",
+      "description": "Geolocate one or more IPs and return ISP/ASN details."
+    },
+    {
+      "name": "ipinfo_lookup_my_ip",
+      "description": "Geolocate the calling client's own IP. No arguments."
+    },
+    {
+      "name": "ipinfo_summarize_ips",
+      "description": "Aggregate one or more IP lookups into counts and percentages."
     }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,101 @@
+{
+  "manifest_version": "0.4",
+  "name": "mcp-server-ipinfo",
+  "display_name": "IP Geolocation (IPInfo)",
+  "version": "0.6.0",
+  "description": "IP Geolocation Server for MCP",
+  "author": {
+    "name": "Brian Connelly",
+    "email": "bdc@bconnelly.net"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/briandconnelly/mcp-server-ipinfo"
+  },
+  "homepage": "https://github.com/briandconnelly/mcp-server-ipinfo",
+  "documentation": "https://github.com/briandconnelly/mcp-server-ipinfo#readme",
+  "support": "https://github.com/briandconnelly/mcp-server-ipinfo/issues",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "ipinfo",
+    "geolocation",
+    "ip",
+    "asn",
+    "vpn"
+  ],
+  "server": {
+    "type": "uv",
+    "entry_point": "src/mcp_server_ipinfo/server.py",
+    "mcp_config": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "${__dirname}",
+        "--frozen",
+        "mcp-server-ipinfo"
+      ],
+      "env": {
+        "IPINFO_API_TOKEN": "${user_config.api_token}",
+        "IPINFO_CACHE_TTL": "${user_config.cache_ttl}",
+        "IPINFO_CACHE_SIZE": "${user_config.cache_size}"
+      }
+    }
+  },
+  "compatibility": {
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "runtimes": {
+      "python": ">=3.13"
+    }
+  },
+  "user_config": {
+    "api_token": {
+      "type": "string",
+      "title": "IPInfo API Token",
+      "description": "Your ipinfo.io API token. Leave blank to run in the free Lite tier (country and ASN basics). Sign up at https://ipinfo.io/signup.",
+      "sensitive": true,
+      "required": false
+    },
+    "cache_ttl": {
+      "type": "number",
+      "title": "Cache TTL (seconds)",
+      "description": "How long per-IP results are cached before re-fetching.",
+      "default": 3600,
+      "required": false
+    },
+    "cache_size": {
+      "type": "number",
+      "title": "Cache Size (entries)",
+      "description": "Maximum cached IP results before oldest-first eviction.",
+      "default": 4096,
+      "required": false
+    }
+  },
+  "tools": [
+    {
+      "name": "ipinfo_lookup_my_ip",
+      "description": "Geolocate the calling client's own IP. No arguments."
+    },
+    {
+      "name": "ipinfo_lookup_ips",
+      "description": "Geolocate one or more IPs and return ISP/ASN details."
+    },
+    {
+      "name": "ipinfo_summarize_ips",
+      "description": "Aggregate one or more IP lookups into counts and percentages."
+    },
+    {
+      "name": "ipinfo_check_residential_proxy",
+      "description": "Classify whether an IP is a known residential-proxy exit node."
+    },
+    {
+      "name": "ipinfo_generate_map_url",
+      "description": "Build an interactive ipinfo.io map for a set of IPs."
+    }
+  ]
+}

--- a/scripts/gen_manifest.py
+++ b/scripts/gen_manifest.py
@@ -22,8 +22,6 @@ import sys
 import tomllib
 from pathlib import Path
 
-import fastmcp
-
 from mcp_server_ipinfo.server import mcp
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -37,12 +35,12 @@ KEYWORDS = ["mcp", "ipinfo", "geolocation", "ip", "asn", "vpn"]
 def _tools() -> list[dict[str, str]]:
     """Manifest ``tools`` entries, derived from the server's registered tools so
     the name/description pairs stay in lockstep with the live server. The
-    description is each tool's first line (the one-sentence summary)."""
-
-    async def _list() -> list[dict[str, str]]:
-        async with fastmcp.Client(mcp) as client:
-            tools = await client.list_tools()
-        return [
+    description is each tool's first line (the one-sentence summary). Sorted by
+    name so the generated manifest is byte-stable regardless of registration
+    order (the committed file is drift-guarded by byte equality)."""
+    tools = asyncio.run(mcp.list_tools())
+    return sorted(
+        (
             {
                 "name": tool.name,
                 "description": (tool.description or "")
@@ -51,9 +49,9 @@ def _tools() -> list[dict[str, str]]:
                 .strip(),
             }
             for tool in tools
-        ]
-
-    return asyncio.run(_list())
+        ),
+        key=lambda entry: entry["name"],
+    )
 
 
 def build_manifest() -> dict:

--- a/scripts/gen_manifest.py
+++ b/scripts/gen_manifest.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+"""Generate ``manifest.json`` (the MCPB bundle manifest) from a single source
+of truth.
+
+Identity (name/version/description/author) comes from ``pyproject.toml``; the
+tool list is derived from the server's own registered tools so the manifest
+cannot drift from what the server actually exposes. ``tests/test_manifest.py``
+asserts the committed ``manifest.json`` matches this generator's output, so
+regenerate and commit whenever the version or tool surface changes.
+
+Usage:
+    uv run python scripts/gen_manifest.py            # write manifest.json
+    uv run python scripts/gen_manifest.py --check     # exit 1 if stale
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import tomllib
+from pathlib import Path
+
+import fastmcp
+
+from mcp_server_ipinfo.server import mcp
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+MANIFEST = REPO_ROOT / "manifest.json"
+
+REPO_URL = "https://github.com/briandconnelly/mcp-server-ipinfo"
+KEYWORDS = ["mcp", "ipinfo", "geolocation", "ip", "asn", "vpn"]
+
+
+def _tools() -> list[dict[str, str]]:
+    """Manifest ``tools`` entries, derived from the server's registered tools so
+    the name/description pairs stay in lockstep with the live server. The
+    description is each tool's first line (the one-sentence summary)."""
+
+    async def _list() -> list[dict[str, str]]:
+        async with fastmcp.Client(mcp) as client:
+            tools = await client.list_tools()
+        return [
+            {
+                "name": tool.name,
+                "description": (tool.description or "")
+                .strip()
+                .split("\n", 1)[0]
+                .strip(),
+            }
+            for tool in tools
+        ]
+
+    return asyncio.run(_list())
+
+
+def build_manifest() -> dict:
+    project = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))["project"]
+    author = project["authors"][0]
+
+    return {
+        "manifest_version": "0.4",
+        "name": project["name"],
+        "display_name": "IP Geolocation (IPInfo)",
+        "version": project["version"],
+        "description": project["description"],
+        "author": {"name": author["name"], "email": author["email"]},
+        "repository": {"type": "git", "url": REPO_URL},
+        "homepage": REPO_URL,
+        "documentation": f"{REPO_URL}#readme",
+        "support": f"{REPO_URL}/issues",
+        "license": "MIT",
+        "keywords": KEYWORDS,
+        "server": {
+            "type": "uv",
+            "entry_point": "src/mcp_server_ipinfo/server.py",
+            "mcp_config": {
+                "command": "uv",
+                "args": [
+                    "run",
+                    "--directory",
+                    "${__dirname}",
+                    "--frozen",
+                    "mcp-server-ipinfo",
+                ],
+                "env": {
+                    "IPINFO_API_TOKEN": "${user_config.api_token}",
+                    "IPINFO_CACHE_TTL": "${user_config.cache_ttl}",
+                    "IPINFO_CACHE_SIZE": "${user_config.cache_size}",
+                },
+            },
+        },
+        "compatibility": {
+            "platforms": ["darwin", "linux", "win32"],
+            "runtimes": {"python": ">=3.13"},
+        },
+        "user_config": {
+            "api_token": {
+                "type": "string",
+                "title": "IPInfo API Token",
+                "description": (
+                    "Your ipinfo.io API token. Leave blank to run in the free Lite "
+                    "tier (country and ASN basics). Sign up at https://ipinfo.io/signup."
+                ),
+                "sensitive": True,
+                "required": False,
+            },
+            "cache_ttl": {
+                "type": "number",
+                "title": "Cache TTL (seconds)",
+                "description": "How long per-IP results are cached before re-fetching.",
+                "default": 3600,
+                "required": False,
+            },
+            "cache_size": {
+                "type": "number",
+                "title": "Cache Size (entries)",
+                "description": "Maximum cached IP results before oldest-first eviction.",
+                "default": 4096,
+                "required": False,
+            },
+        },
+        "tools": _tools(),
+    }
+
+
+def render(manifest: dict) -> str:
+    """Deterministic JSON rendering used for both writing and drift comparison."""
+    return json.dumps(manifest, indent=2, ensure_ascii=False) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if manifest.json is missing or stale (do not write).",
+    )
+    args = parser.parse_args()
+
+    rendered = render(build_manifest())
+
+    if args.check:
+        current = MANIFEST.read_text(encoding="utf-8") if MANIFEST.exists() else ""
+        if current != rendered:
+            print(
+                "manifest.json is out of date; run: uv run python scripts/gen_manifest.py"
+            )
+            return 1
+        print("manifest.json is up to date.")
+        return 0
+
+    MANIFEST.write_text(rendered, encoding="utf-8")
+    print(f"Wrote {MANIFEST.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -23,6 +23,12 @@ gen_manifest = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(gen_manifest)
 
 
+def _load_manifest() -> dict:
+    """Load the committed manifest, failing clearly if it is missing."""
+    assert MANIFEST.exists(), "manifest.json missing; run scripts/gen_manifest.py"
+    return json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+
 def test_manifest_in_sync():
     """Committed manifest.json byte-equals the generator output (regenerate and
     commit after bumping the version or changing tools)."""
@@ -40,14 +46,13 @@ async def test_manifest_tools_match_server():
     async with fastmcp.Client(mcp) as client:
         registered = {t.name for t in await client.list_tools()}
 
-    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
-    advertised = {t["name"] for t in manifest["tools"]}
+    advertised = {t["name"] for t in _load_manifest()["tools"]}
     assert advertised == registered
 
 
 def test_manifest_required_fields():
     """MCPB-required top-level fields are present and the server is a uv bundle."""
-    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    manifest = _load_manifest()
     for field in (
         "manifest_version",
         "name",
@@ -74,5 +79,4 @@ def test_manifest_version_matches_package():
     """Manifest version tracks the packaged version."""
     from importlib.metadata import version
 
-    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
-    assert manifest["version"] == version("mcp-server-ipinfo")
+    assert _load_manifest()["version"] == version("mcp-server-ipinfo")

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,78 @@
+"""Guards for the MCPB bundle manifest.
+
+These mirror the project's other contract/drift tests: the committed
+``manifest.json`` must equal what ``scripts/gen_manifest.py`` produces, and its
+advertised tool surface must match the server's actually-registered tools.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import fastmcp
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = REPO_ROOT / "manifest.json"
+
+# scripts/ is not an installed package, so load the generator by file path.
+_spec = importlib.util.spec_from_file_location(
+    "gen_manifest", REPO_ROOT / "scripts" / "gen_manifest.py"
+)
+assert _spec is not None and _spec.loader is not None
+gen_manifest = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gen_manifest)
+
+
+def test_manifest_in_sync():
+    """Committed manifest.json byte-equals the generator output (regenerate and
+    commit after bumping the version or changing tools)."""
+    assert MANIFEST.exists(), "manifest.json missing; run scripts/gen_manifest.py"
+    expected = gen_manifest.render(gen_manifest.build_manifest())
+    assert MANIFEST.read_text(encoding="utf-8") == expected, (
+        "manifest.json is stale; run: uv run python scripts/gen_manifest.py"
+    )
+
+
+async def test_manifest_tools_match_server():
+    """The manifest's tool names match the server's registered tools exactly."""
+    from mcp_server_ipinfo.server import mcp
+
+    async with fastmcp.Client(mcp) as client:
+        registered = {t.name for t in await client.list_tools()}
+
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    advertised = {t["name"] for t in manifest["tools"]}
+    assert advertised == registered
+
+
+def test_manifest_required_fields():
+    """MCPB-required top-level fields are present and the server is a uv bundle."""
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    for field in (
+        "manifest_version",
+        "name",
+        "version",
+        "description",
+        "author",
+        "server",
+    ):
+        assert field in manifest, f"missing required manifest field: {field}"
+
+    assert manifest["manifest_version"] == "0.4"
+    assert manifest["server"]["type"] == "uv"
+    # The bundle's run target must be a real file shipped in the archive.
+    assert (REPO_ROOT / manifest["server"]["entry_point"]).exists()
+
+    # The token is optional (the server runs in free Lite mode without it) but
+    # must be collected as a masked secret when provided.
+    api_token = manifest["user_config"]["api_token"]
+    assert api_token["required"] is False
+    assert api_token["sensitive"] is True
+
+
+def test_manifest_version_matches_package():
+    """Manifest version tracks the packaged version."""
+    from importlib.metadata import version
+
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    assert manifest["version"] == version("mcp-server-ipinfo")


### PR DESCRIPTION
## Summary

Adds MCPB (`.mcpb`) bundle packaging so the server installs into Claude Desktop in one click, using the `server.type: "uv"` runtime (ships `src/` + `uv.lock`, resolves Python/deps at install time).

`manifest.json` is **generated** from `pyproject.toml` plus the server's registered tools by `scripts/gen_manifest.py` — the same pattern used in `mcp-server-tempest` — and drift-guarded by `tests/test_manifest.py`. Token and cache settings are exposed as install-time `user_config`; leaving the token blank runs the free Lite tier.

## Changes

- **`scripts/gen_manifest.py`** — generates `manifest.json`; `tools[]` derived from the live server (first docstring line); cache fields typed `number`; `--check` mode for CI.
- **`manifest.json`** — generated, committed, validates against MCPB v0.4.
- **`tests/test_manifest.py`** — drift (byte-equality), tools-match-server, required fields, version-matches-package.
- **`.github/workflows/mcpb.yml`** — reusable workflow: `gen --check` → validate → pack `dist/mcp-server-ipinfo-<version>.mcpb` → forbidden-path assertion → upload to release + artifact.
- **`.github/workflows/publish.yml`** — `publish` job asserts `tag == pyproject` + manifest sync; dependent `bundle` job calls `mcpb.yml` after the release exists.
- **`.mcpbignore`**, **`AGENTS.md`**, **`CHANGELOG.md`**, **`README.md`** — docs + ignore rules for the generated-manifest flow.

## Verification

- `ruff` clean, `ty` clean (pre-commit hooks passed)
- `gen_manifest.py --check` passes
- `mcpb validate` passes; pack produces 10 clean files (no secrets/tests/dev cruft)
- 200 tests pass, 98.5% coverage

Local launch verified: `uv run --directory . --frozen mcp-server-ipinfo` starts and blocks on stdio. The live Claude Desktop install was not exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)