### PR TITLE
Harden agent-facing contract (second Claude+Codex re-audit, 0.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-07
+
+A second joint Claude + Codex agent-friendliness pass, plus MCPB bundle
+packaging. Focus: discoverability for clients that ignore the `instructions`
+field, and token-bounded per-record responses.
+
 ### Added
 - MCPB bundle packaging for one-click install in Claude Desktop. A `manifest.json`
   (`server.type: "uv"`) is generated from `pyproject.toml` and the server's tools by
@@ -14,6 +20,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   workflow packs a version-stamped `.mcpb` and attaches it to the GitHub release. The
   token and cache settings are exposed as install-time `user_config`; leaving the token
   blank runs the free Lite tier.
+- `ipinfo://capabilities` resource: a structured, JSON capability summary carrying a
+  surface `fingerprint` (sha256 over tool names, input fields, annotations, error
+  codes, and negative scope — version-independent so clients can detect real surface
+  changes), the negative scope, plan tiers, the full error-code catalog, cache and
+  long-running behavior, and the per-tool contract. Gives clients that drop the
+  advisory `instructions` field a machine-readable discovery surface.
+- Human-facing `title` on every tool (e.g. "Look Up IPs", "Check Residential Proxy")
+  for clients with a capability picker.
+- `retry_after_ms` is now populated on rate-limit (HTTP 429) failures that carry an
+  upstream `Retry-After` header (previously always absent).
+
+### Changed
+- **Breaking (discovery):** convention tool metadata (`introduced_in`, `error_codes`,
+  `plan_required`, plus a new `invalid_ip_behavior`) moved under the namespaced
+  `_meta` key `net.bconnelly.ipinfo/contract` so it cannot collide with future native
+  MCP `_meta` fields. Read `tool.meta["net.bconnelly.ipinfo/contract"]`.
+- **Breaking (behavior):** `ipinfo_lookup_ips` is now capped at 1,000 IPs per call
+  (was 500,000); it returns one record per IP, so larger batches raise `too_many_ips`
+  with a repair hint routing to `ipinfo_summarize_ips` (fixed-size aggregates) or
+  `ipinfo_generate_map_url`. Both of those keep the 500,000-IP ceiling. `lookup_ips`
+  also gained a 120s tool timeout.
+- serverInfo name is now `IPInfo Geolocation` (was the longer
+  "IP Address Geolocation and Internet Service Provider Lookup"), giving a concise
+  service-prefixed identity for multiplexed clients.
+- Server-authored result models (`MapResult`, `SummaryResult`, `GroupCount`,
+  `SkippedIP`, the error envelope) now emit closed (`additionalProperties: false`)
+  output schemas; `IPDetails`/`ResidentialProxyDetails` stay open by design since they
+  are parsed from the evolving upstream payload.
+- Tool descriptions disambiguate the general `privacy` flags on `ipinfo_lookup_ips`
+  (VPN/Tor/open-proxy/hosting) from `ipinfo_check_residential_proxy`, and the cache
+  eviction wording is clarified ("oldest insertion/update first; reads do not refresh
+  age").
 
 ## [0.6.0] - 2026-05-31
 
@@ -242,7 +280,8 @@ The previous tool names remain as forwarding aliases scheduled for removal in
 - Response caching with 1-hour TTL
 - Pydantic models for API responses
 
-[Unreleased]: https://github.com/briandconnelly/mcp-server-ipinfo/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/briandconnelly/mcp-server-ipinfo/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/briandconnelly/mcp-server-ipinfo/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/briandconnelly/mcp-server-ipinfo/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/briandconnelly/mcp-server-ipinfo/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/briandconnelly/mcp-server-ipinfo/compare/v0.3.0...v0.4.0

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "mcp-server-ipinfo",
   "display_name": "IP Geolocation (IPInfo)",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "IP Geolocation Server for MCP",
   "author": {
     "name": "Brian Connelly",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-ipinfo"
-version = "0.6.0"
+version = "0.7.0"
 description = "IP Geolocation Server for MCP"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/mcp_server_ipinfo/models.py
+++ b/src/mcp_server_ipinfo/models.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field, StringConstraints, computed_field
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, computed_field
 from pydantic.networks import HttpUrl, IPvAnyAddress
 
 
@@ -27,6 +27,10 @@ class ToolErrorEnvelope(BaseModel):
     a ``ToolError`` so that the wire-level ``isError: true`` still applies
     while the message body remains parseable.
     """
+
+    # Server-authored model: constructed only from the fixed fields below, so
+    # the output schema is closed (``additionalProperties: false``).
+    model_config = ConfigDict(extra="forbid")
 
     code: ToolErrorCode
     """Stable symbolic identifier for branching on the error."""
@@ -229,6 +233,10 @@ class ResidentialProxyDetails(BaseModel):
     Available in: IPinfo Enterprise (with residential proxy add-on)
     """
 
+    # Open like IPDetails: parsed from the upstream ``details.all`` payload, so
+    # extras are ignored rather than forbidden for forward-compatibility.
+    model_config = ConfigDict(extra="ignore")
+
     ip: IPvAnyAddress
     """The IP address that was checked"""
 
@@ -273,6 +281,15 @@ class IPDetails(BaseModel):
     - IPinfo Enterprise: adds domains and abuse contacts; the residential-proxy
       add-on (separate purchase) powers ipinfo_check_residential_proxy
     """
+
+    # Intentionally OPEN (extra fields ignored, not forbidden): this model is
+    # parsed directly from the upstream IPInfo response (``details.all``), whose
+    # field set grows across plan tiers and over time. Forbidding extras would
+    # turn any new upstream field into a hard parse failure on a real lookup, so
+    # the output schema is deliberately not closed here (see §3 "intentional,
+    # documented contract" exception). Server-authored result models
+    # (MapResult, SummaryResult, etc.) ARE closed.
+    model_config = ConfigDict(extra="ignore")
 
     ip: IPvAnyAddress
     """The IP address (IPv4 or IPv6)"""
@@ -377,6 +394,8 @@ class IPDetails(BaseModel):
 class SkippedIP(BaseModel):
     """A single input IP that was filtered out before reaching the upstream API."""
 
+    model_config = ConfigDict(extra="forbid")
+
     ip: str
     """The original input string (preserved before normalization for traceability)."""
 
@@ -391,6 +410,8 @@ class MapResult(BaseModel):
     submitted IPs actually made the map, and which were filtered out (with
     reasons), without re-validating client-side.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     url: HttpUrl
     """URL of the interactive map on ipinfo.io."""
@@ -411,6 +432,8 @@ class MapResult(BaseModel):
 class GroupCount(BaseModel):
     """A counted summary bucket for a group in ``SummaryResult``."""
 
+    model_config = ConfigDict(extra="forbid")
+
     key: str
     """Group key, such as ``US``, ``AS15169 Google LLC``, or ``vpn``."""
 
@@ -423,6 +446,8 @@ class GroupCount(BaseModel):
 
 class SummaryResult(BaseModel):
     """Fixed-size aggregate summary for a batch of IP lookups."""
+
+    model_config = ConfigDict(extra="forbid")
 
     mapped_ip_count: int
     """IPs that successfully looked up and contributed to the aggregate."""

--- a/src/mcp_server_ipinfo/server.py
+++ b/src/mcp_server_ipinfo/server.py
@@ -1,3 +1,4 @@
+import hashlib
 import ipaddress
 import json
 import uuid
@@ -18,7 +19,7 @@ from ipinfo.error import APIError
 from ipinfo.exceptions import RequestQuotaExceededError, TimeoutExceededError
 from pydantic import Field
 
-from .cache import IPInfoCache
+from .cache import DEFAULT_MAX_SIZE, IPInfoCache
 from .ipinfo import (
     UPSTREAM_NO_RESULT_REASON,
     create_async_handler,
@@ -61,15 +62,32 @@ except PackageNotFoundError:  # pragma: no cover - editable tree without metadat
     __version__ = "0.0.0+unknown"
 
 
+# Agent-facing serverInfo identity. Carries a service prefix ("IPInfo") so it
+# disambiguates at a glance in a multiplexed client without colliding with a
+# generic name like "geolocation". The MCPB package/display names live in
+# manifest.json; this is the name agents see over the wire.
+SERVER_NAME = "IPInfo Geolocation"
+
+# Reverse-DNS namespace for this server's convention `_meta` extensions, so they
+# cannot collide with future native MCP `_meta` fields (per the agent-friendly
+# MCP convention). bconnelly.net -> net.bconnelly.
+CONTRACT_NS = "net.bconnelly.ipinfo/contract"
+
+
 # Create an MCP server
 mcp = FastMCP(
-    name="IP Address Geolocation and Internet Service Provider Lookup",
+    name=SERVER_NAME,
     version=__version__,
     website_url="https://github.com/briandconnelly/mcp-server-ipinfo",
     instructions="""
     Geolocate IPv4/IPv6 addresses via ipinfo.io: location, ISP, ASN, and
     (on paid plans) privacy/VPN/Tor/proxy flags, carrier, company, abuse
     contacts, hosted domains.
+
+    Machine-readable capability summary (negative scope, plan tiers, error-code
+    catalog, per-tool contract, and a surface `fingerprint` for change
+    detection) is the `ipinfo://capabilities` resource. Read it instead of
+    parsing this prose if your client surfaces MCP resources.
 
     Tools:
     - ipinfo_lookup_my_ip(): the calling client's own IP (no args).
@@ -82,7 +100,10 @@ mcp = FastMCP(
       them); if the batch resolves no IPs at all, the failure is raised rather
       than masked — auth_insufficient_scope when the upstream returned nothing
       (token tier likely lacks /batch access; look IPs up one at a time or
-      upgrade to Core+), otherwise a retryable api_error.
+      upgrade to Core+), otherwise a retryable api_error. Returns one record
+      per IP and is capped at 1,000 IPs (too_many_ips above that) — for larger
+      batches use ipinfo_summarize_ips (fixed-size aggregates) or
+      ipinfo_generate_map_url.
     - ipinfo_summarize_ips(ips, group_by=["country", "asn"]): batch lookup
       plus server-side aggregation into fixed-size counts/percentages, for
       large log-analysis tasks where per-IP records would waste context.
@@ -106,8 +127,14 @@ mcp = FastMCP(
 
     Cache (lookup tools only — not residential-proxy or map): in-memory,
     IPINFO_CACHE_TTL seconds (default 3600), max IPINFO_CACHE_SIZE entries
-    (default 4096), oldest evicted first. `ts_retrieved` on a cached record
+    (default 4096); when full, the oldest insertion/update is evicted first
+    (reads do not refresh an entry's age). `ts_retrieved` on a cached record
     is the original lookup time — compare against now for freshness.
+
+    Long-running behavior: the batch tools emit best-effort progress
+    notifications (a no-op unless your client supplied a progressToken). No
+    tool supports the MCP task lifecycle; treat every call as a single
+    request/response and rely on the per-tool timeouts instead.
 
     Transport: on stdio, ipinfo_lookup_my_ip resolves to this server's
     outbound IP, not the end user's. Use ipinfo_lookup_ips with an explicit
@@ -117,8 +144,10 @@ mcp = FastMCP(
     (auth_invalid, auth_insufficient_scope, quota_exceeded, timeout,
     api_error, invalid_ip_address, special_ip_unsupported, no_valid_ips,
     too_many_ips, unknown_error), a `temporary` flag, an optional
-    `retry_after_ms`, and a `repair` hint. Parse the message as JSON and
-    branch on `code`.
+    `retry_after_ms` (populated on rate-limit/429 responses that carry an
+    upstream Retry-After header), and a `repair` hint. Parse the message as
+    JSON and branch on `code`. The same code catalog is in the
+    `ipinfo://capabilities` resource.
     """,
     lifespan=app_lifespan,
 )
@@ -203,7 +232,41 @@ _SINGLE_IP_TOOL_ERROR_CODES = [
 # my_ip takes no input, so only upstream/auth codes apply.
 _MY_IP_TOOL_ERROR_CODES = list(_UPSTREAM_ERROR_CODES)
 
+
+def _contract_meta(
+    *,
+    introduced_in: str,
+    error_codes: list[str],
+    invalid_ip_behavior: str,
+    plan_required: str | None = None,
+) -> dict[str, Any]:
+    """Build a tool's namespaced convention ``_meta`` block (see ``CONTRACT_NS``).
+
+    All house-style contract metadata lives under one reverse-DNS key so it
+    cannot collide with future native MCP ``_meta`` fields. Agents read
+    ``tool.meta[CONTRACT_NS]`` for the branch set (``error_codes``), the version
+    marker (``introduced_in``), whether bad IPs are skipped per-item or raised
+    (``invalid_ip_behavior``: ``skip_per_item`` | ``raise`` | ``not_applicable``),
+    and any plan gating (``plan_required``).
+    """
+    contract: dict[str, Any] = {
+        "introduced_in": introduced_in,
+        "stability": "stable",
+        "error_codes": error_codes,
+        "invalid_ip_behavior": invalid_ip_behavior,
+    }
+    if plan_required is not None:
+        contract["plan_required"] = plan_required
+    return {CONTRACT_NS: contract}
+
+
 MAX_LOOKUP_IPS = 500_000
+# Per-record cap for ipinfo_lookup_ips specifically. Its response grows one
+# IPDetails record per resolved IP, so an unbounded batch would blow the
+# context window; the fixed-size ipinfo_summarize_ips and the single-URL
+# ipinfo_generate_map_url keep the full MAX_LOOKUP_IPS ceiling. Exceeding this
+# raises a structured too_many_ips that points the agent at those tools.
+MAX_DETAILED_LOOKUP_IPS = 1_000
 MAX_SUMMARY_GROUPS = 500
 DEFAULT_SUMMARY_TOP_N = 50
 
@@ -221,6 +284,10 @@ MAX_SKIP_WARNINGS = 100
 # tighter per-request timeout (DEFAULT_MAP_TIMEOUT_SECONDS).
 MAP_TOOL_TIMEOUT_SECONDS = 60.0
 SUMMARY_TOOL_TIMEOUT_SECONDS = 120.0
+# Framework guard on the per-record batch tool. With the 1,000-IP cap above,
+# the upstream /batch call is bounded, but a hung connection still needs a
+# ceiling so the tool returns a structured timeout rather than blocking.
+LOOKUP_TOOL_TIMEOUT_SECONDS = 120.0
 
 
 @dataclass(frozen=True)
@@ -258,6 +325,25 @@ def _raise_envelope(
         request_id=uuid.uuid4().hex,
     )
     raise ToolError(envelope.model_dump_json())
+
+
+def _parse_retry_after(value: str | None) -> int | None:
+    """Parse an HTTP ``Retry-After`` header into milliseconds, or ``None``.
+
+    Handles the ``delta-seconds`` form (e.g. ``"120"``), which is what IPInfo
+    emits on a 429. The HTTP-date form is not parsed (returns ``None``) because
+    the upstream does not use it; populating ``retry_after_ms`` only from a
+    value we can interpret keeps the field honest rather than guessing.
+    """
+    if not value:
+        return None
+    try:
+        seconds = int(value.strip())
+    except ValueError:
+        return None
+    if seconds < 0:
+        return None
+    return seconds * 1000
 
 
 def _envelope_from_upstream(
@@ -363,7 +449,7 @@ def _envelope_from_upstream(
                 "quota_exceeded",
                 "IPInfo rate limit exceeded.",
                 True,
-                None,
+                _parse_retry_after(exc.response.headers.get("Retry-After")),
                 {"hint": "Wait for the rate-limit window to reset."},
             )
         if 500 <= status < 600:
@@ -830,8 +916,13 @@ def _summarize_ip_details(
         "readOnlyHint": True,
         "openWorldHint": True,
         "idempotentHint": True,
+        "title": "Look Up My IP",
     },
-    meta={"introduced_in": "0.5.0", "error_codes": _MY_IP_TOOL_ERROR_CODES},
+    meta=_contract_meta(
+        introduced_in="0.5.0",
+        error_codes=_MY_IP_TOOL_ERROR_CODES,
+        invalid_ip_behavior="not_applicable",
+    ),
 )
 async def ipinfo_lookup_my_ip(
     ctx: Context = CurrentContext(),
@@ -851,8 +942,14 @@ async def ipinfo_lookup_my_ip(
         "readOnlyHint": True,
         "openWorldHint": True,
         "idempotentHint": True,
+        "title": "Look Up IPs",
     },
-    meta={"introduced_in": "0.5.0", "error_codes": _LIST_TOOL_ERROR_CODES},
+    meta=_contract_meta(
+        introduced_in="0.5.0",
+        error_codes=_LIST_TOOL_ERROR_CODES,
+        invalid_ip_behavior="skip_per_item",
+    ),
+    timeout=LOOKUP_TOOL_TIMEOUT_SECONDS,
 )
 async def ipinfo_lookup_ips(
     ips: Annotated[
@@ -860,7 +957,7 @@ async def ipinfo_lookup_ips(
         Field(
             description="IPv4/IPv6 addresses to look up. Invalid or special-use IPs are filtered.",
             min_length=1,
-            max_length=MAX_LOOKUP_IPS,
+            max_length=MAX_DETAILED_LOOKUP_IPS,
             examples=[["8.8.8.8"], ["8.8.8.8", "1.1.1.1", "208.67.222.222"]],
         ),
     ],
@@ -885,12 +982,41 @@ async def ipinfo_lookup_ips(
     returned nothing (token tier likely lacks `/batch` access; look IPs up one
     at a time or upgrade to Core+), otherwise a retryable `api_error`. Defaults
     to `detail="summary"` (heavy nested blocks
-    omitted); pass `detail="full"` for every field. Capped at 500,000 IPs per
-    call (`too_many_ips` if exceeded). Higher plan tiers populate more fields;
-    see the server instructions for the Lite/Core/Plus/Enterprise tier mapping.
+    omitted); pass `detail="full"` for every field. Capped at 1,000 IPs per
+    call (`too_many_ips` above that): this tool returns one record per IP, so
+    for larger batches use `ipinfo_summarize_ips` (fixed-size aggregates) or
+    `ipinfo_generate_map_url`. Higher plan tiers populate more fields; see the
+    server instructions for the Lite/Core/Plus/Enterprise tier mapping. For
+    VPN/Tor/open-proxy/hosting detection read the `privacy` flags on each
+    record; for residential-proxy exit-node classification use the separate
+    `ipinfo_check_residential_proxy` tool. Typically completes in seconds;
+    bounded by a 120s tool timeout that surfaces as a `timeout` envelope.
     Errors raise ToolError with a JSON-encoded envelope.
     """
     handler, cache = _get_handler_and_cache(ctx)
+    # Per-record cap (schema also enforces max_length; this covers callers that
+    # bypass FastMCP validation). The aggregate/map tools keep the larger
+    # MAX_LOOKUP_IPS ceiling, so the repair hint routes oversized batches there.
+    if len(ips) > MAX_DETAILED_LOOKUP_IPS:
+        _raise_envelope(
+            "too_many_ips",
+            f"Too many IPs ({len(ips):,}) for per-record lookup. "
+            f"Maximum is {MAX_DETAILED_LOOKUP_IPS:,}.",
+            temporary=False,
+            field="ips",
+            value=len(ips),
+            repair={
+                "limit": MAX_DETAILED_LOOKUP_IPS,
+                "received": len(ips),
+                "hint": (
+                    "ipinfo_lookup_ips returns one record per IP and is capped "
+                    f"at {MAX_DETAILED_LOOKUP_IPS:,}. For larger batches call "
+                    "ipinfo_summarize_ips for fixed-size aggregates, or "
+                    "ipinfo_generate_map_url to plot them."
+                ),
+                "alternatives": ["ipinfo_summarize_ips", "ipinfo_generate_map_url"],
+            },
+        )
     results = await _do_batch_lookup(handler, cache, ips, ctx)
     if detail == "summary":
         # Project to token-lean dicts. The return annotation stays
@@ -907,8 +1033,13 @@ async def ipinfo_lookup_ips(
         "readOnlyHint": True,
         "openWorldHint": True,
         "idempotentHint": True,
+        "title": "Summarize IPs",
     },
-    meta={"introduced_in": "0.6.0", "error_codes": _LIST_TOOL_ERROR_CODES},
+    meta=_contract_meta(
+        introduced_in="0.6.0",
+        error_codes=_LIST_TOOL_ERROR_CODES,
+        invalid_ip_behavior="skip_per_item",
+    ),
     timeout=SUMMARY_TOOL_TIMEOUT_SECONDS,
 )
 async def ipinfo_summarize_ips(
@@ -971,12 +1102,14 @@ async def ipinfo_summarize_ips(
         "readOnlyHint": True,
         "openWorldHint": True,
         "idempotentHint": True,
+        "title": "Check Residential Proxy",
     },
-    meta={
-        "introduced_in": "0.5.0",
-        "plan_required": "residential_proxy_addon",
-        "error_codes": _SINGLE_IP_TOOL_ERROR_CODES,
-    },
+    meta=_contract_meta(
+        introduced_in="0.5.0",
+        error_codes=_SINGLE_IP_TOOL_ERROR_CODES,
+        invalid_ip_behavior="raise",
+        plan_required="residential_proxy_addon",
+    ),
     tags={"enterprise"},
 )
 async def ipinfo_check_residential_proxy(
@@ -995,7 +1128,10 @@ async def ipinfo_check_residential_proxy(
     Returns ResidentialProxyDetails with `is_residential_proxy` (the canonical
     yes/no), and — when true — `service`, `last_seen` (YYYY-MM-DD), and
     `percent_days_seen` over a 7-day window. Useful for fraud, bot, and
-    ad-fraud detection. Requires IPINFO_API_TOKEN with the Enterprise
+    ad-fraud detection. This is distinct from the general `privacy` flags on
+    `ipinfo_lookup_ips` (VPN / Tor / open web proxy / hosting): use this tool
+    only to detect residential-proxy networks that route traffic through real
+    residential IPs. Requires IPINFO_API_TOKEN with the Enterprise
     residential-proxy add-on; absence surfaces as `auth_insufficient_scope`
     (distinct from `auth_invalid` for a missing/wrong token).
     """
@@ -1019,8 +1155,13 @@ async def ipinfo_check_residential_proxy(
         "readOnlyHint": True,
         "openWorldHint": True,
         "idempotentHint": True,
+        "title": "Generate IP Map URL",
     },
-    meta={"introduced_in": "0.5.0", "error_codes": _LIST_TOOL_ERROR_CODES},
+    meta=_contract_meta(
+        introduced_in="0.5.0",
+        error_codes=_LIST_TOOL_ERROR_CODES,
+        invalid_ip_behavior="skip_per_item",
+    ),
     timeout=MAP_TOOL_TIMEOUT_SECONDS,
 )
 async def ipinfo_generate_map_url(
@@ -1097,3 +1238,164 @@ async def ipinfo_generate_map_url(
             "truncated": truncated,
         }
     )
+
+
+# --- Capability summary resource (agent discovery surface) -------------------
+#
+# A structured, fingerprinted capability summary exposed as an MCP resource so
+# clients that drop the advisory `instructions` field still get negative scope,
+# plan tiers, the error-code catalog, and the per-tool contract. The fingerprint
+# lets a cached client detect surface changes without re-walking every tool.
+
+# What this server does NOT do. Stated as data (not only prose) so an agent can
+# rule the server in or out without a failed call.
+NEGATIVE_SCOPE: tuple[str, ...] = (
+    "DNS / hostname resolution",
+    "CIDR or BGP / prefix lookups",
+    "historical or time-series data",
+    "private / loopback / multicast / link-local / reserved IPs "
+    "(filtered at the boundary as special_ip_unsupported)",
+    "deanonymizing users behind VPN / proxy / Tor (results reflect the exit point)",
+    "malice / threat / abuse scoring",
+)
+
+# IPINFO_API_TOKEN plan tiers and the fields each unlocks.
+PLAN_TIERS: dict[str, str] = {
+    "none": "country, country_code, continent, ASN basics",
+    "core": "full geolocation, ASN details, privacy/VPN/proxy/Tor/hosting flags",
+    "plus": "carrier, company",
+    "enterprise": "domains, abuse contacts",
+    "residential_proxy_addon": (
+        "ipinfo_check_residential_proxy (separate purchase on top of Enterprise)"
+    ),
+}
+
+# Every stable error `code` an agent may branch on, with a one-line meaning.
+# Keys must stay in sync with the ToolErrorCode literal in models.py.
+ERROR_CODE_CATALOG: dict[str, str] = {
+    "invalid_ip_address": "Input was not a parseable IPv4/IPv6 address.",
+    "special_ip_unsupported": (
+        "IP is private/loopback/multicast/link-local/reserved; not geolocatable."
+    ),
+    "no_valid_ips": "Every input IP was filtered out; nothing to look up.",
+    "too_many_ips": "Batch exceeded the tool's input cap.",
+    "auth_invalid": "IPINFO_API_TOKEN missing or rejected (HTTP 401).",
+    "auth_insufficient_scope": (
+        "Token tier/add-on lacks access to this capability "
+        "(HTTP 403, or an empty /batch response on a Lite token)."
+    ),
+    "quota_exceeded": "Request quota or rate limit exhausted (HTTP 429).",
+    "timeout": "Upstream request timed out.",
+    "api_error": "IPInfo returned a server error (HTTP 5xx) or an unusable payload.",
+    "unknown_error": "Unclassified failure; see message and exception_type.",
+}
+
+
+async def _surface_records() -> list[dict[str, Any]]:
+    """Project the live tool registry into stable, sorted per-tool contract records."""
+    tools = await mcp.list_tools()
+    records: list[dict[str, Any]] = []
+    for tool in sorted(tools, key=lambda t: t.name):
+        params = tool.parameters or {}
+        properties = params.get("properties") or {}
+        contract = (tool.meta or {}).get(CONTRACT_NS, {})
+        ann = tool.annotations
+        records.append(
+            {
+                "name": tool.name,
+                "title": getattr(ann, "title", None),
+                "input_fields": sorted(properties.keys()),
+                "required": sorted(params.get("required") or []),
+                "introduced_in": contract.get("introduced_in"),
+                "stability": contract.get("stability"),
+                "error_codes": sorted(contract.get("error_codes", [])),
+                "invalid_ip_behavior": contract.get("invalid_ip_behavior"),
+                "plan_required": contract.get("plan_required"),
+                "annotations": {
+                    "readOnlyHint": getattr(ann, "readOnlyHint", None),
+                    "idempotentHint": getattr(ann, "idempotentHint", None),
+                    "openWorldHint": getattr(ann, "openWorldHint", None),
+                },
+            }
+        )
+    return records
+
+
+def _compute_fingerprint(records: list[dict[str, Any]]) -> str:
+    """Deterministic hash over the agent-visible surface.
+
+    Covers tool names, input fields, required args, annotations, error codes,
+    and introduced_in, plus the negative scope and the error-code catalog keys.
+    It deliberately EXCLUDES the package version, so a release that does not
+    change the surface keeps the same fingerprint — a client can observe
+    "version moved but fingerprint identical" and skip re-walking discovery.
+    Pure function of the surface (no time or randomness), so it is stable across
+    runs and machines.
+    """
+    canonical = json.dumps(
+        {
+            "tools": records,
+            "negative_scope": list(NEGATIVE_SCOPE),
+            "error_codes": sorted(ERROR_CODE_CATALOG),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
+
+@mcp.resource(
+    "ipinfo://capabilities",
+    name="capabilities",
+    description=(
+        "Structured capability summary: surface fingerprint, negative scope, "
+        "plan tiers, error-code catalog, cache and long-running behavior, and "
+        "the per-tool contract. Read this to plan calls without parsing the "
+        "server instructions prose."
+    ),
+    mime_type="application/json",
+    meta={CONTRACT_NS: {"introduced_in": "0.7.0", "stability": "stable"}},
+)
+async def capabilities() -> str:
+    """Serve the machine-readable capability summary as a JSON document."""
+    records = await _surface_records()
+    payload = {
+        "server": {"name": SERVER_NAME, "version": __version__},
+        "fingerprint": _compute_fingerprint(records),
+        "fingerprint_covers": [
+            "tool names",
+            "tool input fields",
+            "required args",
+            "tool annotations",
+            "error codes",
+            "negative scope",
+        ],
+        "transport_note": (
+            "On stdio, ipinfo_lookup_my_ip resolves the server's outbound IP, "
+            "not the end user's. Pass an explicit IP to ipinfo_lookup_ips when "
+            "the caller already has one."
+        ),
+        "negative_scope": list(NEGATIVE_SCOPE),
+        "plan_tiers": PLAN_TIERS,
+        "error_code_catalog": ERROR_CODE_CATALOG,
+        "cache": {
+            "applies_to": [
+                "ipinfo_lookup_my_ip",
+                "ipinfo_lookup_ips",
+                "ipinfo_summarize_ips",
+            ],
+            "ttl_seconds": {"env": "IPINFO_CACHE_TTL", "default": 3600},
+            "max_entries": {"env": "IPINFO_CACHE_SIZE", "default": DEFAULT_MAX_SIZE},
+            "eviction": "oldest insertion/update first; reads do not refresh age",
+        },
+        "long_running": {
+            "progress": "best_effort; no-op unless the client sends a progressToken",
+            "task_support": "none",
+        },
+        "limits": {
+            "max_detailed_lookup_ips": MAX_DETAILED_LOOKUP_IPS,
+            "max_lookup_ips": MAX_LOOKUP_IPS,
+        },
+        "tools": records,
+    }
+    return json.dumps(payload, indent=2)

--- a/src/mcp_server_ipinfo/server.py
+++ b/src/mcp_server_ipinfo/server.py
@@ -1331,6 +1331,12 @@ def _compute_fingerprint(records: list[dict[str, Any]]) -> str:
     "version moved but fingerprint identical" and skip re-walking discovery.
     Pure function of the surface (no time or randomness), so it is stable across
     runs and machines.
+
+    Returns the full SHA-256 hex digest with a ``sha256:`` prefix so the label
+    matches the value. Clients treat it as an opaque equality token (the
+    canonicalization is server-internal and not independently recomputable), so
+    a shorter digest would suffice for change-detection — but emitting the full
+    digest keeps the ``sha256:`` prefix honest at negligible cost.
     """
     canonical = json.dumps(
         {
@@ -1341,7 +1347,7 @@ def _compute_fingerprint(records: list[dict[str, Any]]) -> str:
         sort_keys=True,
         separators=(",", ":"),
     )
-    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
 @mcp.resource(

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -42,7 +42,13 @@ class TestCapabilitiesResource:
 
     async def test_carries_fingerprint(self):
         payload = await _read_capabilities()
-        assert payload["fingerprint"].startswith("sha256:")
+        fingerprint = payload["fingerprint"]
+        assert fingerprint.startswith("sha256:")
+        # The label must match the value: a full 64-char SHA-256 hex digest,
+        # not a truncated one (PR #73 review).
+        digest = fingerprint.removeprefix("sha256:")
+        assert len(digest) == 64
+        assert all(c in "0123456789abcdef" for c in digest)
 
     async def test_negative_scope_present(self):
         payload = await _read_capabilities()

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,0 +1,110 @@
+"""Tests for the ipinfo://capabilities discovery resource and its fingerprint.
+
+The resource gives clients that ignore the advisory `instructions` field a
+structured capability summary, and the fingerprint lets a cached client detect
+surface changes without re-walking every tool definition.
+"""
+
+import json
+from typing import get_args
+
+import fastmcp
+
+from mcp_server_ipinfo.models import ToolErrorCode
+from mcp_server_ipinfo.server import (
+    ERROR_CODE_CATALOG,
+    _compute_fingerprint,
+    _surface_records,
+    mcp,
+)
+
+
+async def _read_capabilities() -> dict:
+    """Read and parse the capabilities resource through a real FastMCP client."""
+    async with fastmcp.Client(mcp) as client:
+        contents = await client.read_resource("ipinfo://capabilities")
+    return json.loads(contents[0].text)
+
+
+class TestCapabilitiesResource:
+    async def test_resource_is_registered(self):
+        async with fastmcp.Client(mcp) as client:
+            uris = {str(r.uri) for r in await client.list_resources()}
+        assert "ipinfo://capabilities" in uris
+
+    async def test_reports_server_identity(self):
+        payload = await _read_capabilities()
+        assert payload["server"]["name"] == "IPInfo Geolocation"
+        # Version tracks the installed package, not a hardcoded string.
+        from importlib.metadata import version
+
+        assert payload["server"]["version"] == version("mcp-server-ipinfo")
+
+    async def test_carries_fingerprint(self):
+        payload = await _read_capabilities()
+        assert payload["fingerprint"].startswith("sha256:")
+
+    async def test_negative_scope_present(self):
+        payload = await _read_capabilities()
+        joined = " ".join(payload["negative_scope"]).lower()
+        # The headline out-of-scope items must be visible as data, not prose.
+        assert "dns" in joined
+        assert "bgp" in joined or "cidr" in joined
+
+    async def test_error_catalog_matches_literal(self):
+        """Every ToolErrorCode is documented in the catalog and vice versa."""
+        payload = await _read_capabilities()
+        catalog_codes = set(payload["error_code_catalog"])
+        literal_codes = set(get_args(ToolErrorCode))
+        assert catalog_codes == literal_codes
+
+    async def test_lists_every_tool_with_contract(self):
+        payload = await _read_capabilities()
+        names = {t["name"] for t in payload["tools"]}
+        assert names == {
+            "ipinfo_lookup_my_ip",
+            "ipinfo_lookup_ips",
+            "ipinfo_summarize_ips",
+            "ipinfo_check_residential_proxy",
+            "ipinfo_generate_map_url",
+        }
+        for tool in payload["tools"]:
+            assert tool["title"]
+            assert tool["introduced_in"]
+            assert "invalid_ip_behavior" in tool
+
+    async def test_limits_reflect_split_caps(self):
+        payload = await _read_capabilities()
+        assert payload["limits"]["max_detailed_lookup_ips"] == 1_000
+        assert payload["limits"]["max_lookup_ips"] == 500_000
+
+
+class TestFingerprint:
+    async def test_deterministic(self):
+        """Same surface -> identical fingerprint across calls."""
+        records = await _surface_records()
+        assert _compute_fingerprint(records) == _compute_fingerprint(records)
+
+    async def test_changes_when_surface_changes(self):
+        records = await _surface_records()
+        baseline = _compute_fingerprint(records)
+        mutated = [dict(records[0], error_codes=[*records[0]["error_codes"], "zzz"])]
+        mutated += records[1:]
+        assert _compute_fingerprint(mutated) != baseline
+
+    async def test_independent_of_package_version(self):
+        """The fingerprint covers the surface, not the version string.
+
+        Two records sets that differ only in nothing version-related hash the
+        same; the version lives in a separate payload field so a client can see
+        'version moved but fingerprint identical'.
+        """
+        records = await _surface_records()
+        payload = await _read_capabilities()
+        # The fingerprint input does not include payload["server"]["version"].
+        assert _compute_fingerprint(records) == payload["fingerprint"]
+
+
+def test_error_catalog_keys_are_valid_codes():
+    """Guard: catalog keys cannot drift from the ToolErrorCode literal."""
+    assert set(ERROR_CODE_CATALOG) == set(get_args(ToolErrorCode))

--- a/tests/test_lookup_cap.py
+++ b/tests/test_lookup_cap.py
@@ -1,0 +1,40 @@
+"""ipinfo_lookup_ips caps per-record output and routes overflow to aggregates.
+
+The per-record tool returns one IPDetails per IP, so a huge batch would blow the
+context window. It is capped tighter than the aggregate/map tools and raises a
+structured too_many_ips that points the agent at the right alternative.
+"""
+
+import json
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from mcp_server_ipinfo.server import MAX_DETAILED_LOOKUP_IPS, ipinfo_lookup_ips
+
+
+async def test_over_cap_raises_too_many_ips(mock_context_with_state):
+    # The cap check runs on len(ips) before validation, so placeholder strings
+    # are fine here — we are exercising the boundary, not the lookup.
+    oversized = ["8.8.8.8"] * (MAX_DETAILED_LOOKUP_IPS + 1)
+
+    with pytest.raises(ToolError) as excinfo:
+        await ipinfo_lookup_ips(ips=oversized, ctx=mock_context_with_state)
+
+    envelope = json.loads(str(excinfo.value))
+    assert envelope["code"] == "too_many_ips"
+    assert envelope["temporary"] is False
+    assert envelope["repair"]["limit"] == MAX_DETAILED_LOOKUP_IPS
+    # The repair hint must name real callable alternatives.
+    assert envelope["repair"]["alternatives"] == [
+        "ipinfo_summarize_ips",
+        "ipinfo_generate_map_url",
+    ]
+
+
+async def test_at_cap_is_allowed(mock_context_with_state):
+    """Exactly at the cap is fine (boundary is strictly greater-than)."""
+    at_cap = ["8.8.8.8"] * MAX_DETAILED_LOOKUP_IPS
+    # All duplicates collapse to one resolved record; the point is no raise.
+    results = await ipinfo_lookup_ips(ips=at_cap, ctx=mock_context_with_state)
+    assert len(results) == 1

--- a/tests/test_retry_after.py
+++ b/tests/test_retry_after.py
@@ -1,0 +1,47 @@
+"""Tests for retry_after_ms population from upstream Retry-After headers.
+
+Before 0.7.0 the envelope advertised retry_after_ms but never populated it. The
+map path now reads the Retry-After header on a 429 and surfaces it in ms.
+"""
+
+import httpx
+
+from mcp_server_ipinfo.server import _envelope_from_upstream, _parse_retry_after
+
+
+class TestParseRetryAfter:
+    def test_none_for_missing(self):
+        assert _parse_retry_after(None) is None
+        assert _parse_retry_after("") is None
+
+    def test_delta_seconds_to_ms(self):
+        assert _parse_retry_after("30") == 30_000
+        assert _parse_retry_after(" 5 ") == 5_000
+
+    def test_http_date_form_unparsed(self):
+        # We intentionally do not parse the HTTP-date form; IPInfo uses seconds.
+        assert _parse_retry_after("Wed, 21 Oct 2026 07:28:00 GMT") is None
+
+    def test_negative_rejected(self):
+        assert _parse_retry_after("-1") is None
+
+
+class TestEnvelopeRetryAfter:
+    def _http_429(self, headers: dict) -> httpx.HTTPStatusError:
+        request = httpx.Request("POST", "https://ipinfo.io/map?cli=1")
+        response = httpx.Response(429, headers=headers, request=request)
+        return httpx.HTTPStatusError("rate limited", request=request, response=response)
+
+    def test_429_populates_retry_after_ms(self):
+        code, _msg, temporary, retry_after_ms, _repair = _envelope_from_upstream(
+            self._http_429({"Retry-After": "12"})
+        )
+        assert code == "quota_exceeded"
+        assert temporary is True
+        assert retry_after_ms == 12_000
+
+    def test_429_without_header_is_none(self):
+        _code, _msg, _temp, retry_after_ms, _repair = _envelope_from_upstream(
+            self._http_429({})
+        )
+        assert retry_after_ms is None

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -17,6 +17,13 @@ async def registered_tools():
     return {tool.name: tool for tool in tools}
 
 
+def _contract(tool) -> dict:
+    """Extract a tool's namespaced convention contract block from its meta."""
+    from mcp_server_ipinfo.server import CONTRACT_NS
+
+    return (tool.meta or {}).get(CONTRACT_NS, {})
+
+
 class TestNewToolSchemas:
     """Constraints that agents need to see in the schema."""
 
@@ -24,7 +31,9 @@ class TestNewToolSchemas:
         tool = registered_tools["ipinfo_lookup_ips"]
         ips_schema = tool.parameters["properties"]["ips"]
         assert ips_schema["minItems"] == 1
-        assert ips_schema["maxItems"] == 500_000
+        # Per-record tool is capped tighter than the aggregate/map tools so a
+        # large batch cannot blow the context window.
+        assert ips_schema["maxItems"] == 1_000
 
     async def test_lookup_ips_detail_is_enum(self, registered_tools):
         tool = registered_tools["ipinfo_lookup_ips"]
@@ -125,14 +134,14 @@ class TestToolContract:
         ],
     )
     async def test_tools_advertise_error_codes(self, registered_tools, name, expected):
-        """Each tool's meta.error_codes lets agents see the branch set up front."""
+        """Each tool's contract error_codes lets agents see the branch set up front."""
         tool = registered_tools[name]
-        codes = set(tool.meta.get("error_codes", []))
+        codes = set(_contract(tool).get("error_codes", []))
         assert expected <= codes, f"{name} missing {expected - codes}"
 
     async def test_my_ip_omits_input_only_error_codes(self, registered_tools):
         """my_ip takes no input, so input-validation codes must not appear."""
-        codes = set(registered_tools["ipinfo_lookup_my_ip"].meta["error_codes"])
+        codes = set(_contract(registered_tools["ipinfo_lookup_my_ip"])["error_codes"])
         assert "invalid_ip_address" not in codes
         assert "too_many_ips" not in codes
 
@@ -143,7 +152,7 @@ class TestToolContract:
     async def test_list_tools_omit_per_item_input_codes(self, registered_tools, name):
         """List tools demote per-item invalid/special IPs to the skipped list
         rather than raising, so those codes must not be advertised as raiseable."""
-        codes = set(registered_tools[name].meta["error_codes"])
+        codes = set(_contract(registered_tools[name])["error_codes"])
         assert "invalid_ip_address" not in codes
         assert "special_ip_unsupported" not in codes
 
@@ -182,9 +191,37 @@ class TestNewToolMetadata:
         tool = registered_tools[name]
         assert tool.meta is not None
         expected = "0.6.0" if name == "ipinfo_summarize_ips" else "0.5.0"
-        assert tool.meta.get("introduced_in") == expected
+        assert _contract(tool).get("introduced_in") == expected
 
     async def test_residential_proxy_marked_enterprise(self, registered_tools):
         tool = registered_tools["ipinfo_check_residential_proxy"]
         assert "enterprise" in (tool.tags or set())
-        assert tool.meta.get("plan_required") == "residential_proxy_addon"
+        assert _contract(tool).get("plan_required") == "residential_proxy_addon"
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("ipinfo_lookup_my_ip", "not_applicable"),
+            ("ipinfo_lookup_ips", "skip_per_item"),
+            ("ipinfo_summarize_ips", "skip_per_item"),
+            ("ipinfo_generate_map_url", "skip_per_item"),
+            ("ipinfo_check_residential_proxy", "raise"),
+        ],
+    )
+    async def test_invalid_ip_behavior_declared(self, registered_tools, name, expected):
+        """Agents can see whether bad IPs are skipped per-item or raised."""
+        assert _contract(registered_tools[name]).get("invalid_ip_behavior") == expected
+
+    @pytest.mark.parametrize(
+        ("name", "title"),
+        [
+            ("ipinfo_lookup_my_ip", "Look Up My IP"),
+            ("ipinfo_lookup_ips", "Look Up IPs"),
+            ("ipinfo_summarize_ips", "Summarize IPs"),
+            ("ipinfo_check_residential_proxy", "Check Residential Proxy"),
+            ("ipinfo_generate_map_url", "Generate IP Map URL"),
+        ],
+    )
+    async def test_tools_carry_display_title(self, registered_tools, name, title):
+        """Each tool exposes a human-facing title for capability pickers."""
+        assert registered_tools[name].annotations.title == title

--- a/uv.lock
+++ b/uv.lock
@@ -887,7 +887,7 @@ wheels = [
 
 [[package]]
 name = "mcp-server-ipinfo"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

A second joint **Claude + Codex** agent-friendliness re-audit of the server against the `agent-friendly-mcp` contract checklist (the 0.6.0 cycle was the first). Implements all twelve aligned findings. Bumps to **0.7.0**.

Net assessment: one Major (no capability fingerprint), the rest Minor/Nit — consistent with a server that had already had one pass. No Critical findings.

## Findings implemented

| Finding | § | Sev | Change |
|---|---|---|---|
| F1 | §2/§9 | Major | New `ipinfo://capabilities` resource: version-independent sha256 surface **fingerprint**, negative scope, plan tiers, error-code catalog, cache/long-running behavior, per-tool contract |
| F2 | §8 | Minor | `lookup_ips` capped at **1,000** (was 500K); overflow → structured `too_many_ips` routing to `summarize_ips`/`generate_map_url` (which keep the 500K ceiling) |
| F3 | §7 | Minor | `lookup_ips` gains a 120s `timeout=` + duration note |
| F4 | §6 | Minor | `retry_after_ms` populated from the upstream `Retry-After` header on 429s |
| F5 | §1 | Nit | serverInfo name → `IPInfo Geolocation` |
| F6 | §3 | Nit | Server-authored models emit `additionalProperties:false`; upstream-fed models documented as intentionally open |
| M1 | §3 | Minor | Docstrings disambiguate `privacy` flags vs `check_residential_proxy` |
| M2 | §1/§3 | Minor | `invalid_ip_behavior` added to each tool's contract |
| M3 | §1 | Nit | Cache eviction wording clarified |
| M4 | §1/§7 | Nit | Progress documented best-effort + no task support |
| M5 | §1 | Nit | Human-facing `title` on all five tools |
| M6 | §3/§9 | Nit | Convention meta moved under namespaced `net.bconnelly.ipinfo/contract` |

## Breaking changes (pre-1.0)

- Convention tool metadata now lives under `tool.meta["net.bconnelly.ipinfo/contract"]` (was top-level keys).
- `ipinfo_lookup_ips` rejects batches over 1,000 IPs with `too_many_ips` (was 500,000).

Both documented in `CHANGELOG.md`.

## Verification

- `229 passed`, coverage **98.48%** (gate 95%)
- `ty` clean · `ruff` clean+formatted · `gen_manifest.py --check` in sync
- **Live smoke suite: 9/9 passed** against the real IPInfo API

## Design notes

- The fingerprint deliberately **excludes** the package version, so a release that doesn't change the surface keeps the same fingerprint — clients can see "version moved, fingerprint identical → skip re-walk."
- F6 is scoped: `IPDetails`/`ResidentialProxyDetails` are parsed from the evolving upstream `.all` payload, so forbidding extras would break real lookups; only server-constructed models are closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)