### PR TITLE
ci: stop attaching dist/.gitignore to releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,13 @@ jobs:
       - uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
-          files: dist/*
+          # Attach only the build artifacts, not everything in dist/. A bare
+          # `dist/*` also sweeps up the committed `dist/.gitignore`, which lands
+          # on the release as a stray `default.gitignore` asset. The .mcpb is
+          # uploaded separately by the dependent bundle job.
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
 
   # Build and attach the .mcpb bundle after the release exists. Called
   # explicitly (not via a release trigger) because a release created with


### PR DESCRIPTION
## Problem

Every GitHub release (through v0.7.0) carried a stray `default.gitignore` asset. The release step used `files: dist/*`, which globs the committed `dist/.gitignore` alongside the wheel/sdist; the action uploads it under the sanitized name `default.gitignore`.

## Fix

Narrow the glob in `publish.yml` to the actual build artifacts:

```yaml
files: |
  dist/*.whl
  dist/*.tar.gz
```

The `.mcpb` bundle is unaffected — it's uploaded separately by the dependent `bundle` job (`mcpb.yml`), which already targets a single explicit file.

## Notes

- Cosmetic / release-hygiene only; no code or runtime behavior changes.
- Takes effect on the next tagged release. The stray asset on existing releases (incl. v0.7.0) can be removed manually if desired — say the word and I'll `gh release delete-asset v0.7.0 default.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)